### PR TITLE
set HEV SOC balancing bounds to [min_soc,max_soc] rather than [0,1]

### DIFF
--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -432,7 +432,10 @@ impl RustSimDrive {
                         } else {
                             ess_2fuel_kwh = 0.0;
                         }
-                        init_soc = min(1.0, max(0.0, *self.soc.last().unwrap()));
+                        init_soc = min(
+                            self.veh.max_soc,
+                            max(self.veh.min_soc, *self.soc.last().unwrap()),
+                        );
                     }
                     init_soc
                 } else if self.veh.veh_pt_type == PHEV || self.veh.veh_pt_type == BEV {


### PR DESCRIPTION
@calbaker This PR fixes a bug encountered when using T3CO with newer FASTSim versions (since we change out of bounds SOC to be an error rather than a warning)

This just changes the bounds in the SOC balancing to use [min_soc,max_soc] rather than 0% to 100%, which prevents an out of bounds SOC from cropping up within FASTSim.

@GrantPayneDenver