### PR TITLE
Dummy PR: changed to `drag_coef: VehicleField<f64>`

### DIFF
--- a/rust/fastsim-core/src/simdrive/cyc_mods.rs
+++ b/rust/fastsim-core/src/simdrive/cyc_mods.rs
@@ -332,8 +332,9 @@ impl RustSimDrive {
             };
             let g = self.props.a_grav_mps2;
             let m = self.veh.veh_kg;
-            let rho_cdfa =
-                self.props.air_density_kg_per_m3 * self.veh.drag_coef * self.veh.frontal_area_m2;
+            let rho_cdfa = self.veh.drag_coef.clone()
+                * self.props.air_density_kg_per_m3
+                * self.veh.frontal_area_m2;
             let rrc = self.veh.wheel_rr_coef;
             -1.0 * ((g / v) * (atan_grade_sin + rrc * atan_grade_cos)
                 + (0.5 * rho_cdfa * (1.0 / m) * v))
@@ -533,7 +534,7 @@ impl RustSimDrive {
         let grade_by_distance = Array::from_vec(grade_by_distance);
         let veh_mass_kg = self.veh.veh_kg;
         let air_density_kg_per_m3 = self.props.air_density_kg_per_m3;
-        let cdfa_m2 = self.veh.drag_coef * self.veh.frontal_area_m2;
+        let cdfa_m2 = self.veh.drag_coef.clone() * self.veh.frontal_area_m2;
         let rrc = self.veh.wheel_rr_coef;
         let gravity_m_per_s2 = self.props.a_grav_mps2;
         // distance traveled while stopping via friction-braking (i.e., distance to brake)

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -843,9 +843,9 @@ impl RustSimDrive {
 
         let grade = self.lookup_grade_for_step(i, Some(mps_ach));
 
-        self.drag_kw[i] = 0.5
+        self.drag_kw[i] = self.veh.drag_coef.clone()
+            * 0.5
             * self.props.air_density_kg_per_m3
-            * self.veh.drag_coef
             * self.veh.frontal_area_m2
             * ((self.mps_ach[i - 1] + mps_ach) / 2.0).powf(3.0)
             / 1e3;
@@ -952,21 +952,18 @@ impl RustSimDrive {
                 grade_iter += 1;
                 grade = grade_estimate;
 
-                let drag3 = 1.0 / 16.0
+                let drag3 = self.veh.drag_coef.clone() * 1.0 / 16.0
                     * self.props.air_density_kg_per_m3
-                    * self.veh.drag_coef
                     * self.veh.frontal_area_m2;
                 let accel2 = 0.5 * self.veh.veh_kg / self.cyc.dt_s_at_i(i);
-                let drag2 = 3.0 / 16.0
+                let drag2 = self.veh.drag_coef.clone() * 3.0 / 16.0
                     * self.props.air_density_kg_per_m3
-                    * self.veh.drag_coef
                     * self.veh.frontal_area_m2
                     * self.mps_ach[i - 1];
                 let wheel2 = 0.5 * self.veh.wheel_inertia_kg_m2 * self.veh.num_wheels
                     / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powf(2.0));
-                let drag1 = 3.0 / 16.0
+                let drag1 = self.veh.drag_coef.clone() * 3.0 / 16.0
                     * self.props.air_density_kg_per_m3
-                    * self.veh.drag_coef
                     * self.veh.frontal_area_m2
                     * self.mps_ach[i - 1].powf(2.0);
                 let roll1 = 0.5
@@ -977,9 +974,8 @@ impl RustSimDrive {
                 let ascent1 = 0.5 * self.props.a_grav_mps2 * grade.atan().sin() * self.veh.veh_kg;
                 let accel0 =
                     -0.5 * self.veh.veh_kg * self.mps_ach[i - 1].powf(2.0) / self.cyc.dt_s_at_i(i);
-                let drag0 = 1.0 / 16.0
+                let drag0 = self.veh.drag_coef.clone() * 1.0 / 16.0
                     * self.props.air_density_kg_per_m3
-                    * self.veh.drag_coef
                     * self.veh.frontal_area_m2
                     * self.mps_ach[i - 1].powf(3.0);
                 let roll0 = 0.5

--- a/rust/fastsim-core/src/simdrivelabel.rs
+++ b/rust/fastsim-core/src/simdrivelabel.rs
@@ -10,10 +10,8 @@ use crate::imports::*;
 use crate::params::*;
 use crate::proc_macros::add_pyo3_api;
 use crate::proc_macros::ApproxEq;
-
 #[cfg(feature = "pyo3")]
 use crate::pyo3imports::*;
-
 use crate::simdrive::{RustSimDrive, RustSimDriveParams};
 use crate::vehicle;
 
@@ -759,6 +757,7 @@ pub fn get_label_fe_phev_py(
 #[cfg(test)]
 mod simdrivelabel_tests {
     use super::*;
+    use crate::vehicle_utils::VehicleField;
 
     #[test]
     fn test_get_label_fe_conv() {
@@ -821,7 +820,7 @@ mod simdrivelabel_tests {
             selection: 13,
             veh_year: 2016,
             veh_pt_type: "PHEV".into(),
-            drag_coef: 0.3,
+            drag_coef: VehicleField::new(0.3),
             frontal_area_m2: 2.565,
             glider_kg: 950.564,
             veh_cg_m: 0.53,

--- a/rust/fastsim-core/src/vehicle.rs
+++ b/rust/fastsim-core/src/vehicle.rs
@@ -6,6 +6,7 @@ use crate::params::*;
 use crate::proc_macros::{add_pyo3_api, doc_field, ApproxEq};
 #[cfg(feature = "pyo3")]
 use crate::pyo3imports::*;
+use crate::vehicle_utils::VehicleField;
 
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -102,19 +103,15 @@ pub struct RustVehicle {
     #[serde(skip)]
     #[api(has_orphaned)]
     /// Physical properties, see [RustPhysicalProperties](RustPhysicalProperties)
-    #[doc_field(skip_doc)]
     pub props: RustPhysicalProperties,
     /// Vehicle name
     #[serde(alias = "name")]
-    #[doc_field(skip_doc)]
     pub scenario_name: String,
     /// Vehicle database ID
     #[serde(skip)]
-    #[doc_field(skip_doc)]
     pub selection: u32,
     /// Vehicle year
     #[serde(alias = "vehModelYear")]
-    #[doc_field(skip_doc)]
     pub veh_year: u32,
     /// Vehicle powertrain type, one of \[[CONV](CONV), [HEV](HEV), [PHEV](PHEV), [BEV](BEV)\]
     #[serde(alias = "vehPtType")]
@@ -122,12 +119,12 @@ pub struct RustVehicle {
         path = "VEH_PT_TYPE_OPTIONS_REGEX",
         message = "must be one of [\"Conv\", \"HEV\", \"PHEV\", \"BEV\"]"
     ))]
-    #[doc_field(skip_doc)]
     pub veh_pt_type: String,
     /// Aerodynamic drag coefficient
     #[serde(alias = "dragCoef")]
-    #[validate(range(min = 0))]
-    pub drag_coef: f64,
+    // #[validate(range(min = 0))]
+    #[api(skip_get, skip_set)]
+    pub drag_coef: VehicleField<f64>,
     /// Frontal area, $m^2$
     #[serde(alias = "frontalAreaM2")]
     #[validate(range(min = 0))]
@@ -852,7 +849,7 @@ impl RustVehicle {
             selection: 5,
             veh_year: 2016,
             veh_pt_type: String::from("Conv"),
-            drag_coef: 0.355,
+            drag_coef: VehicleField::new(0.355),
             frontal_area_m2: 3.066,
             glider_kg: 1359.166,
             veh_cg_m: 0.53,
@@ -1175,7 +1172,7 @@ mod tests {
             selection,
             veh_year,
             veh_pt_type, // bad input
-            drag_coef,
+            drag_coef: VehicleField::new(drag_coef),
             frontal_area_m2,
             glider_kg, // bad input
             veh_cg_m,


### PR DESCRIPTION
some tests fail but most pass
despite having `std::ops::Mul` implemented, requires unwieldy use of `clone()` method to satisfy borrow checker