### PR TITLE
F2 aux override speedup

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,4 +1,5 @@
-(cd rust/fastsim-core/ && cargo test) && \
+# build and test with local version of `fastsim-proc-macros`
+(cd rust/fastsim-core/ && cargo test --features dev-proc-macros) && \
 (cd rust/fastsim-cli/ && cargo test) && \
 pip install -qe ".[dev]" && \
 pytest -v python/fastsim/tests/

--- a/build_and_test_published.sh
+++ b/build_and_test_published.sh
@@ -1,0 +1,5 @@
+# build and test with published version of `fastsim-proc-macros`
+(cd rust/fastsim-core/ && cargo test) && \
+(cd rust/fastsim-cli/ && cargo test) && \
+pip install -qe ".[dev]" && \
+pytest -v python/fastsim/tests/

--- a/python/fastsim/demos/demo.py
+++ b/python/fastsim/demos/demo.py
@@ -353,7 +353,8 @@ cyc = fsim.cycle.Cycle.from_file('udds').to_rust()
 t0 = time.time()
 
 sim_drive = fsim.simdrive.RustSimDrive(cyc, veh)
-sim_drive.sim_drive(None, np.array(cyc.time_s) / cyc.time_s[-1] * 10)
+aux_in_kw_override = np.array(cyc.time_s) / cyc.time_s[-1] * 10
+sim_drive.sim_drive(None)
 
 plt.figure()
 plt.plot(cyc.time_s, sim_drive.fc_kw_out_ach, label='FC out')

--- a/python/fastsim/demos/demo.py
+++ b/python/fastsim/demos/demo.py
@@ -70,9 +70,9 @@ v3 = fsim.vehicle.Vehicle.from_vehdb(10, to_rust=True).to_rust()
 # as an input to FASTSim.
 
 # %%
-t0 = time.time()
+t0 = time.perf_counter()
 cyc = fsim.cycle.Cycle.from_file("udds")
-t1 = time.time()
+t1 = time.perf_counter()
 print(f'Time to load cycle: {t1 - t0:.2e} s')
 
 # %% [markdown]
@@ -87,9 +87,9 @@ print(f'Time to load cycle: {t1 - t0:.2e} s')
 # row to the vehicle database CSV.
 
 # %%
-t0 = time.time()
+t0 = time.perf_counter()
 veh = fsim.vehicle.Vehicle.from_vehdb(10)
-print(f'Time to load vehicle: {time.time() - t0:.2e} s')
+print(f'Time to load vehicle: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Run FASTSim
@@ -97,18 +97,18 @@ print(f'Time to load vehicle: {time.time() - t0:.2e} s')
 # %%
 
 # instantiate and run classic version 
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc, veh)
 sim_drive.sim_drive() 
-t_py = time.time() - t0
+t_py = time.perf_counter() - t0
 print(f'Time to simulate: {t_py:.2e} s')
 
 rc = cyc.to_rust()
 rv = veh.to_rust()
-t0 = time.time()
+t0 = time.perf_counter()
 sdr = fsim.simdrive.RustSimDrive(rc, rv)
 sdr.sim_drive() 
-t_rust = time.time() - t0
+t_rust = time.perf_counter() - t0
 print(f'Time to simulate in rust: {t_rust:.2e} s')
 
 print(f"Rust provides a {t_py/t_rust:.5g}x speedup")
@@ -157,7 +157,7 @@ plt.show()
 # Note that auxInKw is the only variable setup to be externally modified
 # as of 1 July 2020
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9)
 cyc = fsim.cycle.Cycle.from_file('udds')
@@ -175,7 +175,7 @@ plt.xlabel('Time [s]')
 plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # %%
 ## Running sim_drive_step() with modified auxInKw using Rust
@@ -183,7 +183,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 # cannot set just an index of an array via the Python bindings to Rust
 # at this time
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9).to_rust()
 cyc = fsim.cycle.Cycle.from_file('udds').to_rust()
@@ -206,7 +206,7 @@ plt.xlabel('Time [s]')
 plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Overriding using a constant value
@@ -216,7 +216,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 # Note that auxInKw is the only variable setup to be externally modified
 # as of 1 July 2020
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9)
 cyc = fsim.cycle.Cycle.from_file('udds')
@@ -232,14 +232,14 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 
 # %%
 ## Running sim_drive_step() with modified auxInKw using Rust
 # Note that auxInKw is the only variable setup to be externally modified
 # as of 1 July 2020
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9).to_rust()
 cyc = fsim.cycle.Cycle.from_file('udds').to_rust()
@@ -255,7 +255,7 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # # %% [markdown]
 # ### Overriding using a time trace
@@ -265,7 +265,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 # Note that auxInKw is the only variable setup to be externally modified
 # as of 1 July 2020
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9)
 cyc = fsim.cycle.Cycle.from_file('udds')
@@ -288,14 +288,14 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # %%
 ## Running sim_drive_step() with modified auxInKw using Rust
 # Note that auxInKw is the only variable setup to be externally modified
 # as of 1 July 2020
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 veh = fsim.vehicle.Vehicle.from_vehdb(9).to_rust()
 cyc = fsim.cycle.Cycle.from_file('udds').to_rust()
@@ -318,7 +318,7 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 
 # %% by assigning positional arguments may require recompile if these
@@ -328,7 +328,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 veh = fsim.vehicle.Vehicle.from_vehdb(9)
 cyc = fsim.cycle.Cycle.from_file('udds')
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 sim_drive = fsim.simdrive.SimDrive(cyc, veh)
 sim_drive.sim_drive(None, cyc.time_s / cyc.time_s[-1] * 10)
@@ -341,7 +341,7 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # %% by assigning positional arguments (using Rust) may require
 # recompile if these arguments have not been passed, but this is the
@@ -350,7 +350,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 veh = fsim.vehicle.Vehicle.from_vehdb(9).to_rust()
 cyc = fsim.cycle.Cycle.from_file('udds').to_rust()
 
-t0 = time.time()
+t0 = time.perf_counter()
 
 sim_drive = fsim.simdrive.RustSimDrive(cyc, veh)
 aux_in_kw_override = np.array(cyc.time_s) / cyc.time_s[-1] * 10
@@ -364,7 +364,7 @@ plt.ylabel('Power [kW]')
 plt.legend()
 plt.show()
 
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ## Batch Drive Cycles - TSDC Drive Cycles
@@ -398,7 +398,7 @@ print(f'Time to simulate: {time.time() - t0:.2e} s')
 # downloadable from the TSDC.
 
 # %%
-t0 = time.time()
+t0 = time.perf_counter()
 data_path = Path(fsim.simdrive.__file__).parent / 'resources/cycles/cmap_subset/'  # path to drive cycles
 
 drive_cycs_df = pd.DataFrame()
@@ -438,8 +438,8 @@ for subdir in veh_dirs:
         drive_cycs_df = pd.concat([drive_cycs_df, tripK_df],ignore_index=True)
         #drive_cycs_df = drive_cycs_df.append(tripK_df,
         #ignore_index=True)
-t1 = time.time()
-print(f'Time to load cycles: {time.time() - t0:.2e} s')
+t1 = time.perf_counter()
+print(f'Time to load cycles: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Load Model, Run FASTSim
@@ -450,7 +450,7 @@ veh = fsim.vehicle.Vehicle.from_vehdb(1)  # load vehicle model
 output = {}
 
 results_df = pd.DataFrame()
-t_start = time.time()
+t_start = time.perf_counter()
 for trp in list(drive_cycs_df.nrel_trip_id.unique()):
     pnts = drive_cycs_df[drive_cycs_df['nrel_trip_id'] == trp].copy()
     pnts['time_local'] = pd.to_datetime(pnts['timestamp'])
@@ -481,7 +481,7 @@ for trp in list(drive_cycs_df.nrel_trip_id.unique()):
     results_df = pd.concat([results_df,pd.DataFrame(output,index=[0])],ignore_index=True)
     output['mpgge'] = sim_drive.mpgge
     
-t_end = time.time()
+t_end = time.perf_counter()
 
 # results_df = results_df.astype(float)
 
@@ -494,7 +494,7 @@ veh = fsim.vehicle.Vehicle.from_vehdb(1).to_rust()  # load vehicle model
 output = {}
 
 rust_results_df = pd.DataFrame()
-t_start = time.time()
+t_start = time.perf_counter()
 for trp in list(drive_cycs_df.nrel_trip_id.unique()):
     pnts = drive_cycs_df[drive_cycs_df['nrel_trip_id'] == trp].copy()
     pnts['time_local'] = pd.to_datetime(pnts['timestamp'])
@@ -525,7 +525,7 @@ for trp in list(drive_cycs_df.nrel_trip_id.unique()):
     #rust_results_df = results_df.append(output, ignore_index=True)
     output['mpgge'] = sim_drive.mpgge
     
-t_end = time.time()
+t_end = time.perf_counter()
 
 # results_df = results_df.astype(float)
 
@@ -591,33 +591,33 @@ plt.show()
 # ## Micro-trip
 
 # %% load vehicle
-t0 = time.time()
+t0 = time.perf_counter()
 veh = fsim.vehicle.Vehicle.from_vehdb(9)
 # veh = veh
-print(f'Time to load vehicle: {time.time() - t0:.2e} s')
+print(f'Time to load vehicle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% generate micro-trip 
-t0 = time.time()
+t0 = time.perf_counter()
 cyc = fsim.cycle.Cycle.from_file("udds")
 microtrips = fsim.cycle.to_microtrips(cyc.get_cyc_dict())
 cyc = fsim.cycle.Cycle.from_dict(microtrips[1])
-print(f'Time to load cycle: {time.time() - t0:.2e} s')
+print(f'Time to load cycle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% simulate
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc, veh)
 sim_drive.sim_drive()
 # sim_drive = fsim.simdrive.SimDriveClassic(cyc, veh)
 # sim_drive.sim_drive()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive_post = fsim.simdrive.SimDrivePost(sim_drive)
 sim_drive_post.set_battery_wear()
 diag = sim_drive_post.get_diagnostics()
-print(f'Time to post process: {time.time() - t0:.2e} s')
+print(f'Time to post process: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Results
@@ -645,36 +645,36 @@ plt.show()
 # non-standard cycle from file
 
 # %% load vehicle
-t0 = time.time()
+t0 = time.perf_counter()
 # load from standalone vehicle file
 veh = fsim.vehicle.Vehicle.from_file('2012_Ford_Fusion.csv') # load vehicle using name
-print(f'Time to load veicle: {time.time() - t0:.2e} s')
+print(f'Time to load veicle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% generate concatenated trip
-t0 = time.time()
+t0 = time.perf_counter()
 # load from cycle file path
 cyc1 = fsim.cycle.Cycle.from_file(
     str(Path(fsim.simdrive.__file__).parent / 'resources/cycles/udds.csv'))
 cyc2 = fsim.cycle.Cycle.from_file("us06")
 cyc_combo = fsim.cycle.concat([cyc1.get_cyc_dict(), cyc2.get_cyc_dict()])
 cyc_combo = fsim.cycle.Cycle.from_dict(cyc_combo)
-print(f'Time to load cycles: {time.time() - t0:.2e} s')
+print(f'Time to load cycles: {time.perf_counter() - t0:.2e} s')
 
 
 # %% simulate
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc_combo, veh)
 sim_drive.sim_drive()
 # sim_drive = fsim.simdrive.SimDriveClassic(cyc, veh)
 # sim_drive.sim_drive()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive_post = fsim.simdrive.SimDrivePost(sim_drive)
 sim_drive_post.set_battery_wear()
 diag = sim_drive_post.get_diagnostics()
-print(f'Time to post process: {time.time() - t0:.2e} s')
+print(f'Time to post process: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Results
@@ -699,7 +699,7 @@ plt.show()
 # ## Cycle comparison
 
 # %% generate concatenated trip
-t0 = time.time()
+t0 = time.perf_counter()
 cyc1 = fsim.cycle.Cycle.from_file("udds")
 cyc2 = fsim.cycle.Cycle.from_file("us06")
 print('Cycle 1 and 2 equal?')
@@ -712,13 +712,13 @@ cyc2dict = cyc2.get_cyc_dict()
 cyc2dict['extra key'] = None
 print('Cycle 1 and 2 equal?')
 print(fsim.cycle.equals(cyc1.get_cyc_dict(), cyc2dict))
-print(f'Time to load and compare cycles: {time.time() - t0:.2e} s')
+print(f'Time to load and compare cycles: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ## Resample
 
 # %%
-t0 = time.time()
+t0 = time.perf_counter()
 cyc = fsim.cycle.Cycle.from_file("udds")
 cyc10Hz = fsim.cycle.Cycle.from_dict(fsim.cycle.resample(cyc.get_cyc_dict(), new_dt=0.1))
 cyc10s = fsim.cycle.Cycle.from_dict(fsim.cycle.resample(cyc.get_cyc_dict(), new_dt=10))
@@ -728,7 +728,7 @@ plt.plot(cyc10s.time_s, cyc10s.mph, marker=',')
 plt.xlabel('Cycle Time [s]')
 plt.ylabel('Vehicle Speed [mph]')
 plt.show()
-print(f'Time to load and resample: {time.time() - t0:.2e} s')
+print(f'Time to load and resample: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ## Concat cycles of different time steps and resample
@@ -736,15 +736,15 @@ print(f'Time to load and resample: {time.time() - t0:.2e} s')
 # high sample rate.  
 
 # %% load vehicle
-t0 = time.time()
+t0 = time.perf_counter()
 # load vehicle using explicit path
 veh = fsim.vehicle.Vehicle.from_file(Path(fsim.simdrive.__file__).parent / 
                       'resources/vehdb/2012_Ford_Fusion.csv')
-print(f'Time to load vehicle: {time.time() - t0:.2e} s')
+print(f'Time to load vehicle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% generate concatenated trip
-t0 = time.time()
+t0 = time.perf_counter()
 cyc_udds = fsim.cycle.Cycle.from_file("udds")
 # Generate cycle with 0.1 s time steps
 cyc_udds_10Hz = fsim.cycle.Cycle.from_dict(
@@ -753,22 +753,22 @@ cyc_us06 = fsim.cycle.Cycle.from_file("us06")
 cyc_combo = fsim.cycle.concat([cyc_udds_10Hz.get_cyc_dict(), cyc_us06.get_cyc_dict()])
 cyc_combo = fsim.cycle.resample(cyc_combo, new_dt=1)
 cyc_combo = fsim.cycle.Cycle.from_dict(cyc_combo)
-print(f'Time to load and concatenate cycles: {time.time() - t0:.2e} s')
+print(f'Time to load and concatenate cycles: {time.perf_counter() - t0:.2e} s')
 
 
 # %% simulate
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc_combo, veh)
 sim_drive.sim_drive()
 # sim_drive = fsim.simdrive.SimDriveClassic(cyc, veh)
 # sim_drive.sim_drive()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive_post = fsim.simdrive.SimDrivePost(sim_drive)
 sim_drive_post.set_battery_wear()
 diag = sim_drive_post.get_diagnostics()
-print(f'Time to post process: {time.time() - t0:.2e} s')
+print(f'Time to post process: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Results
@@ -793,33 +793,33 @@ plt.show()
 # ## Clip by times
 
 # %% load vehicle
-t0 = time.time()
+t0 = time.perf_counter()
 veh = fsim.vehicle.Vehicle.from_vehdb(1)
 # veh = veh
-print(f'Time to load vehicle: {time.time() - t0:.2e} s')
+print(f'Time to load vehicle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% generate micro-trip 
-t0 = time.time()
+t0 = time.perf_counter()
 cyc = fsim.cycle.Cycle.from_file("udds")
 cyc = fsim.cycle.clip_by_times(cyc.get_cyc_dict(), t_end=300)
 cyc = fsim.cycle.Cycle.from_dict(cyc)
-print(f'Time to load and clip cycle: {time.time() - t0:.2e} s')
+print(f'Time to load and clip cycle: {time.perf_counter() - t0:.2e} s')
 
 
 # %% simulate
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc, veh)
 sim_drive.sim_drive()
 # sim_drive = fsim.simdrive.SimDriveClassic(cyc, veh)
 # sim_drive.sim_drive()
-print(f'Time to simulate: {time.time() - t0:.2e} s')
+print(f'Time to simulate: {time.perf_counter() - t0:.2e} s')
 
-t0 = time.time()
+t0 = time.perf_counter()
 sim_drive_post = fsim.simdrive.SimDrivePost(sim_drive)
 sim_drive_post.set_battery_wear()
 diag = sim_drive_post.get_diagnostics()
-print(f'Time to post process: {time.time() - t0:.2e} s')
+print(f'Time to post process: {time.perf_counter() - t0:.2e} s')
 
 # %% [markdown]
 # ### Results

--- a/python/fastsim/demos/timing_demo.py
+++ b/python/fastsim/demos/timing_demo.py
@@ -1,0 +1,114 @@
+# %%
+# local modules
+import fastsim as fsim
+
+# other dependencies
+import sys
+import os
+from pathlib import Path
+import numpy as np
+import time
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns 
+sns.set()
+
+
+# The purpose of this file is to demonstrate that loading files directly into Rust is always faster,
+# and often a lot faster, than loading files in python and then converting.
+
+
+#%% [markdown]
+# # Various ways of instantiating rust cycles
+# Performance on M1 Mac:
+# ```
+# Time to load cycle with `cycle.Cycle.from_file("udds")`: 2.66e-03 s
+# Time to load cycle with `cycle.Cycle.from_file(udds_path)`: 1.58e-03 s
+# Time to load cycle with `fastsimrust.RustCycle.from_file`: 4.29e-04 s
+# ```
+
+t0 = time.perf_counter()
+cyc_python = fsim.cycle.Cycle.from_file("udds").to_rust()
+t1 = time.perf_counter()
+print(f'Time to load cycle with `cycle.Cycle.from_file("udds")`: {t1 - t0:.2e} s')
+
+udds_path = Path(fsim.package_root() / "resources/cycles/udds.csv")
+t0 = time.perf_counter()
+cyc = fsim.cycle.Cycle.from_file(udds_path).to_rust()
+t1 = time.perf_counter()
+print(f'Time to load cycle with `cycle.Cycle.from_file(udds_path)`: {t1 - t0:.2e} s')
+
+t0 = time.perf_counter()
+cyc = fsim.fastsimrust.RustCycle.from_file(str(udds_path))
+t1 = time.perf_counter()
+print(f'Time to load cycle with `fastsimrust.RustCycle.from_file`: {t1 - t0:.2e} s')
+
+
+# %% [markdown]
+# # Two ways of instantiating rust vehicles
+# Performance on M1 Mac:
+# ```
+# Time to load vehicle with
+# `vehicle.Vehicle.from_file(veh_csv_path)`: 9.78e-03 s
+# Time to load vehicle with
+# `fastsimrust.RustVehicle.from_file(veh_yaml_path)`: 5.06e-04 s
+# ```
+
+veh_csv_path = fsim.package_root() / "resources/vehdb/2012_Ford_Fusion.csv"
+t0 = time.perf_counter()
+veh_python = fsim.vehicle.Vehicle.from_file(str(veh_csv_path), to_rust=True)
+print(
+    'Time to load vehicle with\n' + 
+    f'`vehicle.Vehicle.from_file(veh_csv_path)`: {time.perf_counter() - t0:.2e} s'
+)
+
+veh_yaml_path = fsim.package_root() / "resources/vehdb/2012_Ford_Fusion.yaml"
+t0 = time.perf_counter()
+veh = fsim.fastsimrust.RustVehicle.from_file(str(veh_yaml_path))
+print(
+    'Time to load vehicle with\n' + 
+    f'`fastsimrust.RustVehicle.from_file(veh_yaml_path)`: {time.perf_counter() - t0:.2e} s'
+)
+
+# %% [markdown]
+# # Two methods of instantiating and running RustSimDrive
+# These end up being about the same performance on M1 Mac:
+# ```
+# Time to instantiate with `simdrive.RustSimDrive`
+# and simulate in rust: 1.46e-03 s
+# Time to instantiate with `fastsimrust.RustSimDrive`
+# and simulate in rust: 1.31e-03 s
+# ```
+
+t0 = time.perf_counter()
+sdr = fsim.simdrive.RustSimDrive(cyc, veh)
+sdr.sim_drive() 
+t_rust = time.perf_counter() - t0
+print(
+    'Time to instantiate with `simdrive.RustSimDrive`\n' + 
+    f'and simulate in rust: {t_rust:.2e} s')
+
+t0 = time.perf_counter()
+sdr = fsim.fastsimrust.RustSimDrive(cyc, veh)
+sdr.sim_drive() 
+t_rust = time.perf_counter() - t0
+print(
+    'Time to instantiate with `fastsimrust.RustSimDrive`\n' + 
+    f'and simulate in rust: {t_rust:.2e} s')
+
+# %% [markdown] 
+# # Instantiating and running RustSimDrive with aux load override, no significant difference
+# Performance no M1 Mac:
+# ```
+# Time to instantiate and simulate in rust with aux load array: 1.20e-03 s
+# ```
+
+t0 = time.perf_counter()
+sdr = fsim.simdrive.RustSimDrive(cyc, veh)
+aux_in_kw_override = np.array(cyc.time_s) / cyc.time_s[-1] * 10
+sdr.sim_drive(None, aux_in_kw_override) 
+t_rust = time.perf_counter() - t0
+print(
+    f'Time to instantiate and simulate in rust ' + 
+    f'with aux load array: {t_rust:.2e} s'
+)

--- a/rust/fastsim-core/Cargo.toml
+++ b/rust/fastsim-core/Cargo.toml
@@ -10,10 +10,11 @@ readme = "../../README.md"
 repository = "https://github.com/NREL/fastsim"
 
 [dependencies]
-# uncomment next line for any development work in fastsim-proc-macros
-proc-macros = { package = "fastsim-proc-macros", path = "./fastsim-proc-macros" }
-# comment next line for any development work in fastsim-proc-macros
-# proc-macros = { package = "fastsim-proc-macros", version = "0.1.4" }
+# this is compiled only when `dev-proc-macros` feature is not enabled, which is the default
+fastsim-proc-macros = { package = "fastsim-proc-macros", version = "0.1.4" }
+# this is compiled when `dev-proc-macros` feature is enabled with e.g. `cargo build --features
+# dev-proc-macros`
+dev-proc-macros = { package = "fastsim-proc-macros", path = "./fastsim-proc-macros" }
 pyo3 = { workspace = true, features = [
     "extension-module",
     "anyhow",
@@ -46,3 +47,4 @@ include = [
 
 [features]
 pyo3 = ["dep:pyo3"]
+dev-proc-macros = []

--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -6,6 +6,11 @@ mod pyo3_api_utils;
 use crate::imports::*;
 
 pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
+    println!(
+        "[{}{}] Using the local dev version of fastsim-proc-macros.",
+        file!(),
+        line!()
+    );
     let mut ast = syn::parse_macro_input!(item as syn::ItemStruct);
     // println!("{}", ast.ident.to_string());
     let ident = &ast.ident;

--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -6,11 +6,6 @@ mod pyo3_api_utils;
 use crate::imports::*;
 
 pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
-    println!(
-        "[{}{}] Using the local dev version of fastsim-proc-macros.",
-        file!(),
-        line!()
-    );
     let mut ast = syn::parse_macro_input!(item as syn::ItemStruct);
     // println!("{}", ast.ident.to_string());
     let ident = &ast.ident;

--- a/rust/fastsim-core/src/imports.rs
+++ b/rust/fastsim-core/src/imports.rs
@@ -10,3 +10,4 @@ pub(crate) use std::path::{Path, PathBuf};
 
 pub(crate) use crate::traits::*;
 pub(crate) use crate::utils::*;
+

--- a/rust/fastsim-core/src/lib.rs
+++ b/rust/fastsim-core/src/lib.rs
@@ -32,7 +32,6 @@ extern crate ndarray;
 
 #[macro_use]
 pub mod macros;
-extern crate proc_macros;
 pub mod air;
 pub mod cycle;
 pub mod imports;
@@ -48,3 +47,8 @@ pub mod utils;
 pub mod vehicle;
 pub mod vehicle_thermal;
 pub mod vehicle_utils;
+
+#[cfg(feature = "dev-proc-macros")]
+pub use dev_proc_macros as proc_macros;
+#[cfg(not(feature = "dev-proc-macros"))]
+pub use fastsim_proc_macros as proc_macros;

--- a/rust/fastsim-core/src/simdrive.rs
+++ b/rust/fastsim-core/src/simdrive.rs
@@ -490,6 +490,9 @@ pub struct RustSimDrive {
     pub idm_target_speed_m_per_s: Array1<f64>,
     #[serde(skip)]
     pub cyc0_cache: RustCycleCache,
+    #[api(skip_get, skip_set)]
+    #[serde(skip)]
+    aux_in_kw_override: Option<Vec<f64>>,
 }
 
 impl SerdeAPI for RustSimDrive {}

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -274,6 +274,7 @@ impl RustSimDrive {
             coast_delay_index,
             idm_target_speed_m_per_s,
             cyc0_cache,
+            aux_in_kw_override: None,
         }
     }
 
@@ -525,8 +526,13 @@ impl RustSimDrive {
 
         self.init_arrays();
 
-        if let Some(arr) = aux_in_kw_override {
-            self.aux_in_kw = arr;
+        // set `self.aux_in_kw_override` if it has been provided and not previously set
+        match aux_in_kw_override {
+            Some(arr) => match self.aux_in_kw_override {
+                Some(_) => {}
+                None => self.aux_in_kw = arr,
+            },
+            None => {}
         }
 
         self.cyc_met[0] = true;

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -527,12 +527,11 @@ impl RustSimDrive {
         self.init_arrays();
 
         // set `self.aux_in_kw_override` if it has been provided and not previously set
-        match aux_in_kw_override {
-            Some(arr) => match self.aux_in_kw_override {
+        if let Some(arr) = aux_in_kw_override {
+            match self.aux_in_kw_override {
                 Some(_) => {}
                 None => self.aux_in_kw = arr,
-            },
-            None => {}
+            }
         }
 
         self.cyc_met[0] = true;

--- a/rust/fastsim-core/src/thermal.rs
+++ b/rust/fastsim-core/src/thermal.rs
@@ -1,6 +1,6 @@
 //! Module for simulating thermal behavior of powertrains
 
-use proc_macros::{add_pyo3_api, HistoryVec};
+use crate::proc_macros::{add_pyo3_api, HistoryVec};
 
 use crate::air::AirProperties;
 use crate::cycle;

--- a/rust/fastsim-core/src/utils.rs
+++ b/rust/fastsim-core/src/utils.rs
@@ -220,7 +220,7 @@ pub fn interpolate_vectors(
 
 #[cfg(feature = "pyo3")]
 pub mod array_wrappers {
-    use proc_macros::add_pyo3_api;
+    use crate::proc_macros::add_pyo3_api;
 
     use super::*;
     /// Helper struct to allow Rust to return a Python class that will indicate to the user that it's a clone.  

--- a/rust/fastsim-core/src/vehicle_thermal.rs
+++ b/rust/fastsim-core/src/vehicle_thermal.rs
@@ -1,11 +1,11 @@
 use crate::imports::*;
+use crate::proc_macros::{add_pyo3_api, HistoryVec};
 #[cfg(feature = "pyo3")]
 use crate::pyo3imports::*;
 #[cfg(feature = "pyo3")]
 use crate::utils;
 #[cfg(feature = "pyo3")]
 use crate::utils::Pyo3VecF64;
-use proc_macros::{add_pyo3_api, HistoryVec};
 use std::f64::consts::PI;
 
 /// Whether FC thermal modeling is handled by FASTSim


### PR DESCRIPTION
- creates new `RustSimDrive` [field]:(https://github.com/NREL/fastsim/blob/c0f12f9d104e22297045ec0691975c96f873a4a2/rust/fastsim-core/src/simdrive.rs#L495)
```
#[api(skip_get, skip_set)]
#[serde(skip)]
aux_in_kw_override: Option<Vec<f64>>,
```
that allows for a persistent array to eliminate the need for repeated cloning.  
- uses matching to cheaply figure out if `aux_in_kw` needs override:
https://github.com/NREL/fastsim/blob/c0f12f9d104e22297045ec0691975c96f873a4a2/rust/fastsim-core/src/simdrive/simdrive_impl.rs#L529