### PR TITLE
F2 proc macro dep fix

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,4 +1,5 @@
-(cd rust/fastsim-core/ && cargo test) && \
+# build and test with local version of `fastsim-proc-macros`
+(cd rust/fastsim-core/ && cargo test --features dev-proc-macros) && \
 (cd rust/fastsim-cli/ && cargo test) && \
 pip install -qe ".[dev]" && \
 pytest -v python/fastsim/tests/

--- a/build_and_test_published.sh
+++ b/build_and_test_published.sh
@@ -1,0 +1,5 @@
+# build and test with published version of `fastsim-proc-macros`
+(cd rust/fastsim-core/ && cargo test) && \
+(cd rust/fastsim-cli/ && cargo test) && \
+pip install -qe ".[dev]" && \
+pytest -v python/fastsim/tests/

--- a/rust/fastsim-core/Cargo.toml
+++ b/rust/fastsim-core/Cargo.toml
@@ -10,10 +10,11 @@ readme = "../../README.md"
 repository = "https://github.com/NREL/fastsim"
 
 [dependencies]
-# uncomment next line for any development work in fastsim-proc-macros
-proc-macros = { package = "fastsim-proc-macros", path = "./fastsim-proc-macros" }
-# comment next line for any development work in fastsim-proc-macros
-# proc-macros = { package = "fastsim-proc-macros", version = "0.1.4" }
+# this is compiled only when `dev-proc-macros` feature is not enabled, which is the default
+fastsim-proc-macros = { package = "fastsim-proc-macros", version = "0.1.4" }
+# this is compiled when `dev-proc-macros` feature is enabled with e.g. `cargo build --features
+# dev-proc-macros`
+dev-proc-macros = { package = "fastsim-proc-macros", path = "./fastsim-proc-macros" }
 pyo3 = { workspace = true, features = [
     "extension-module",
     "anyhow",
@@ -46,3 +47,4 @@ include = [
 
 [features]
 pyo3 = ["dep:pyo3"]
+dev-proc-macros = []

--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -6,6 +6,11 @@ mod pyo3_api_utils;
 use crate::imports::*;
 
 pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
+    println!(
+        "[{}{}] Using the local dev version of fastsim-proc-macros.",
+        file!(),
+        line!()
+    );
     let mut ast = syn::parse_macro_input!(item as syn::ItemStruct);
     // println!("{}", ast.ident.to_string());
     let ident = &ast.ident;

--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -6,11 +6,6 @@ mod pyo3_api_utils;
 use crate::imports::*;
 
 pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
-    println!(
-        "[{}{}] Using the local dev version of fastsim-proc-macros.",
-        file!(),
-        line!()
-    );
     let mut ast = syn::parse_macro_input!(item as syn::ItemStruct);
     // println!("{}", ast.ident.to_string());
     let ident = &ast.ident;

--- a/rust/fastsim-core/src/imports.rs
+++ b/rust/fastsim-core/src/imports.rs
@@ -10,3 +10,4 @@ pub(crate) use std::path::{Path, PathBuf};
 
 pub(crate) use crate::traits::*;
 pub(crate) use crate::utils::*;
+

--- a/rust/fastsim-core/src/lib.rs
+++ b/rust/fastsim-core/src/lib.rs
@@ -32,7 +32,6 @@ extern crate ndarray;
 
 #[macro_use]
 pub mod macros;
-extern crate proc_macros;
 pub mod air;
 pub mod cycle;
 pub mod imports;
@@ -48,3 +47,8 @@ pub mod utils;
 pub mod vehicle;
 pub mod vehicle_thermal;
 pub mod vehicle_utils;
+
+#[cfg(feature = "dev-proc-macros")]
+pub use dev_proc_macros as proc_macros;
+#[cfg(not(feature = "dev-proc-macros"))]
+pub use fastsim_proc_macros as proc_macros;

--- a/rust/fastsim-core/src/thermal.rs
+++ b/rust/fastsim-core/src/thermal.rs
@@ -1,6 +1,6 @@
 //! Module for simulating thermal behavior of powertrains
 
-use proc_macros::{add_pyo3_api, HistoryVec};
+use crate::proc_macros::{add_pyo3_api, HistoryVec};
 
 use crate::air::AirProperties;
 use crate::cycle;

--- a/rust/fastsim-core/src/utils.rs
+++ b/rust/fastsim-core/src/utils.rs
@@ -220,7 +220,7 @@ pub fn interpolate_vectors(
 
 #[cfg(feature = "pyo3")]
 pub mod array_wrappers {
-    use proc_macros::add_pyo3_api;
+    use crate::proc_macros::add_pyo3_api;
 
     use super::*;
     /// Helper struct to allow Rust to return a Python class that will indicate to the user that it's a clone.  

--- a/rust/fastsim-core/src/vehicle_thermal.rs
+++ b/rust/fastsim-core/src/vehicle_thermal.rs
@@ -1,11 +1,11 @@
 use crate::imports::*;
+use crate::proc_macros::{add_pyo3_api, HistoryVec};
 #[cfg(feature = "pyo3")]
 use crate::pyo3imports::*;
 #[cfg(feature = "pyo3")]
 use crate::utils;
 #[cfg(feature = "pyo3")]
 use crate::utils::Pyo3VecF64;
-use proc_macros::{add_pyo3_api, HistoryVec};
 use std::f64::consts::PI;
 
 /// Whether FC thermal modeling is handled by FASTSim


### PR DESCRIPTION
Add `dev-proc-macros` feature in `fastsim-core` that uses local version of `fastsim-proc-macros` when enabled and the published version otherwise.  See example usage in build_and_test.sh and build_and_test_published.sh.  

In rust/fastsim-core/, run `cargo build --features dev-proc-macros`.  