### PR TITLE
using `serde_derive` crate directly rather than `serde` `derive` feature

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,8 @@ codegen-units = 1 # optimize connection between modules
 anyhow = "1.0.57"
 pyo3 = "0.19"
 pyo3-log = "*"
-serde = "1.0.143"
+serde = "1.0.186"
 serde_json = "1.0.83"
 serde_yaml = "0.9.22"
+serde_derive = "1.0.186"
+

--- a/rust/fastsim-cli/Cargo.toml
+++ b/rust/fastsim-cli/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/NREL/fastsim"
 fastsim-core = { path = "../fastsim-core", version = "~0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_derive = { workspace = true }
 project-root = "0.2.2"
 clap = { version = "3.2.6", features = ["derive"] }
 regex = "1"

--- a/rust/fastsim-cli/src/bin/fastsim-cli.rs
+++ b/rust/fastsim-cli/src/bin/fastsim-cli.rs
@@ -1,5 +1,5 @@
 use clap::{ArgGroup, Parser};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use std::fs;

--- a/rust/fastsim-core/Cargo.toml
+++ b/rust/fastsim-core/Cargo.toml
@@ -16,7 +16,8 @@ pyo3 = { workspace = true, features = [
     "anyhow",
 ], optional = true }
 anyhow = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_yaml = { workspace = true }
 ndarray = { version = "0.15.4", features = ["serde"] }
 csv = "1.1"

--- a/rust/fastsim-core/src/imports.rs
+++ b/rust/fastsim-core/src/imports.rs
@@ -2,7 +2,7 @@ pub(crate) use anyhow::{anyhow, bail, ensure};
 pub(crate) use bincode::{deserialize, serialize};
 pub(crate) use log;
 pub(crate) use ndarray::{array, concatenate, s, Array, Array1, Axis};
-pub(crate) use serde::{Deserialize, Serialize};
+pub(crate) use serde_derive::{Deserialize, Serialize};
 pub(crate) use std::cmp;
 pub(crate) use std::ffi::OsStr;
 pub(crate) use std::fs::File;
@@ -10,4 +10,3 @@ pub(crate) use std::path::{Path, PathBuf};
 
 pub(crate) use crate::traits::*;
 pub(crate) use crate::utils::*;
-

--- a/rust/fastsim-core/src/simdrivelabel.rs
+++ b/rust/fastsim-core/src/simdrivelabel.rs
@@ -1,7 +1,7 @@
 //! Module containing classes and methods for calculating label fuel economy.
 
 use ndarray::Array;
-use serde::Serialize;
+use serde_derive::Serialize;
 use std::collections::HashMap;
 
 // crate local

--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::imports::*;
 use std::collections::HashMap;
 
-pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
+pub trait SerdeAPI: serde::Serialize + for<'a> serde::Deserialize<'a> {
     /// runs any initialization steps that might be needed
     fn init(&mut self) -> anyhow::Result<()> {
         Ok(())
@@ -45,7 +45,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
     fn from_file(filename: &str) -> Result<Self, anyhow::Error>
     where
         Self: std::marker::Sized,
-        for<'de> Self: Deserialize<'de>,
+        for<'de> Self: serde::Deserialize<'de>,
     {
         let extension = Path::new(filename)
             .extension()


### PR DESCRIPTION
Apparently, `serde` is now shipping the `serde_derive::{Deserialize, Serialize}` attribute-style proc macros as precompiled binaries.   
https://github.com/serde-rs/serde/issues/2584  
https://www.bleepingcomputer.com/news/security/rust-devs-push-back-as-serde-project-ships-precompiled-binaries/  

dtolnay says he did it to reduce compile times which had gotten quite bad because the derive feature forced certain compilation steps to be sequential.   Apparently, a decent workaround is to use the serde_derive crate directly as a dependency, and it apparently keeps compile times similar to what they are with the pre-compiled binary.  