### PR TITLE
Replace Option::unwrap() with Option::ok_or_else() with descriptive message

### DIFF
--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -19,7 +19,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
     /// # Returns:
     ///
     /// A Rust Result
-    fn to_file(&self, filename: &str) -> Result<(), anyhow::Error> {
+    fn to_file(&self, filename: &str) -> anyhow::Result<()> {
         let file = PathBuf::from(filename);
         match file
             .extension()

--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -25,8 +25,12 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
             .extension()
             .ok_or_else(|| anyhow!("Unable to parse file extension: {:?}", file))?
             .to_str()
-            .unwrap()
-        {
+            .ok_or_else(|| {
+                anyhow!(
+                    "Unable to convert file extension from `&OsStr` to `&str`: {:?}",
+                    file
+                )
+            })? {
             "json" => serde_json::to_writer(&File::create(file)?, self)?,
             "yaml" => serde_yaml::to_writer(&File::create(file)?, self)?,
             _ => serde_json::to_writer(&File::create(file)?, self)?,

--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -21,7 +21,12 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
     /// A Rust Result
     fn to_file(&self, filename: &str) -> Result<(), anyhow::Error> {
         let file = PathBuf::from(filename);
-        match file.extension().unwrap().to_str().unwrap() {
+        match file
+            .extension()
+            .ok_or_else(|| anyhow!("File extension not specified"))?
+            .to_str()
+            .unwrap()
+        {
             "json" => serde_json::to_writer(&File::create(file)?, self)?,
             "yaml" => serde_yaml::to_writer(&File::create(file)?, self)?,
             _ => serde_json::to_writer(&File::create(file)?, self)?,

--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -23,7 +23,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
         let file = PathBuf::from(filename);
         match file
             .extension()
-            .ok_or_else(|| anyhow!("File extension not specified"))?
+            .ok_or_else(|| anyhow!("Unable to parse file extension: {:?}", file))?
             .to_str()
             .unwrap()
         {


### PR DESCRIPTION
<strike>
The only thing I would want your input on this the verbiage of the new error message:

`File extension not specified`

versus the possible times a `None` is returned by `PathBuf::extension()`:
```
The extension is:
- None, if there is no file name;
- None, if there is no embedded .;
- None, if the file name begins with . and has no other .s within;
- Otherwise, the portion of the file name after the final .
```
</strike>

**edit: I think the updated error message is fine.**