### PR TITLE
Update set ach speed

### DIFF
--- a/python/fastsim/__init__.py
+++ b/python/fastsim/__init__.py
@@ -6,6 +6,15 @@ import sys
 import logging
 import traceback
 
+from . import fastsimrust
+from . import fastsimrust as fsr
+from . import parameters as params
+from . import utilities as utils
+from . import simdrive, vehicle, cycle, calibration, tests
+from . import calibration as cal
+from .resample import resample
+from . import auxiliaries
+
 
 def package_root() -> Path:
     """Returns the package root directory."""
@@ -18,16 +27,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
-
-
-from . import fastsimrust
-from . import fastsimrust as fsr
-from . import parameters as params
-from . import utilities as utils
-from . import simdrive, vehicle, cycle, calibration, tests
-from . import calibration as cal
-from .resample import resample
-from . import auxiliaries
 
 from pkg_resources import get_distribution
 

--- a/python/fastsim/demos/__init__.py
+++ b/python/fastsim/demos/__init__.py
@@ -1,4 +1,7 @@
-print(
-    "Module `fastsim.demos` has been imported.  This should only " 
-    + "happen during testing so you might be doing something wrong."
+import logging
+
+logger = logging.getLogger(__name__)
+logger.warning(
+    "Module `fastsim.demos` has been imported. This should only "
+    + "happen during testing, so you might be doing something wrong."
 )

--- a/python/fastsim/demos/__init__.py
+++ b/python/fastsim/demos/__init__.py
@@ -1,0 +1,4 @@
+print(
+    "Module `fastsim.demos` has been imported.  This should only " 
+    + "happen during testing so you might be doing something wrong."
+)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "fastsim-cli",                      # command line app

--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -205,7 +205,6 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
                     });
                 }
             }
-        } else {
         }
     } else {
         abort_call_site!("`add_pyo3_api` works only on named and tuple structs.");

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -886,13 +886,9 @@ impl RustSimDrive {
         self.cyc_tire_inertia_kw[i] = (0.5
             * self.veh.wheel_inertia_kg_m2
             * self.veh.num_wheels
-            * self.cyc_whl_rad_per_sec[i].powi(2)
-            / self.cyc.dt_s_at_i(i)
-            - 0.5
-                * self.veh.wheel_inertia_kg_m2
-                * self.veh.num_wheels
-                * (self.mps_ach[i - 1] / self.veh.wheel_radius_m).powi(2)
-                / self.cyc.dt_s_at_i(i))
+            * (self.cyc_whl_rad_per_sec[i].powi(2)
+                - (self.mps_ach[i - 1] / self.veh.wheel_radius_m).powi(2))
+            / self.cyc.dt_s_at_i(i))
             / 1e3;
 
         self.cyc_whl_kw_req[i] =

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -976,28 +976,65 @@ impl RustSimDrive {
                 grade_iter += 1;
                 grade = grade_estimate;
 
-                let pwr_err = |speed: f64| -> f64 {
-                    (self.veh.veh_kg
-                        + self.veh.num_wheels * self.veh.wheel_inertia_kg_m2
-                            / self.veh.wheel_radius_m.powi(2))
-                        * (speed.powi(2) - self.mps_ach[i - 1].powi(2))
-                        / (2. * self.cyc.dt_s_at_i(i))
-                        + self.veh.veh_kg * self.props.a_grav_mps2 * (speed + self.mps_ach[i - 1])
-                            / 2.
-                            * ({
-                                let theta = grade;
-                                theta.sin() + grade.atan().cos() * self.veh.wheel_rr_coef
-                            })
-                        + 1. / 16.
-                            * self.props.air_density_kg_per_m3
-                            * self.veh.drag_coef
-                            * self.veh.frontal_area_m2
-                            * (speed.powi(3)
-                                + 3. * speed.powi(2) * self.mps_ach[i - 1]
-                                + self.mps_ach[i - 1].powi(3)
-                                + 3. * speed * self.mps_ach[i - 1].powi(2))
-                };
+                let drag3 = 1.0 / 16.0
+                    * self.props.air_density_kg_per_m3
+                    * self.veh.drag_coef
+                    * self.veh.frontal_area_m2;
+                let accel2 = 0.5 * self.veh.veh_kg / self.cyc.dt_s_at_i(i);
+                let drag2 = 3.0 / 16.0
+                    * self.props.air_density_kg_per_m3
+                    * self.veh.drag_coef
+                    * self.veh.frontal_area_m2
+                    * self.mps_ach[i - 1];
+                let wheel2 = 0.5 * self.veh.wheel_inertia_kg_m2 * self.veh.num_wheels
+                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powf(2.0));
+                let drag1 = 3.0 / 16.0
+                    * self.props.air_density_kg_per_m3
+                    * self.veh.drag_coef
+                    * self.veh.frontal_area_m2
+                    * self.mps_ach[i - 1].powf(2.0);
+                let roll1 = 0.5
+                    * self.veh.veh_kg
+                    * self.props.a_grav_mps2
+                    * self.veh.wheel_rr_coef
+                    * grade.atan().cos();
+                let ascent1 = 0.5 * self.props.a_grav_mps2 * grade.atan().sin() * self.veh.veh_kg;
+                let accel0 =
+                    -0.5 * self.veh.veh_kg * self.mps_ach[i - 1].powf(2.0) / self.cyc.dt_s_at_i(i);
+                let drag0 = 1.0 / 16.0
+                    * self.props.air_density_kg_per_m3
+                    * self.veh.drag_coef
+                    * self.veh.frontal_area_m2
+                    * self.mps_ach[i - 1].powf(3.0);
+                let roll0 = 0.5
+                    * self.veh.veh_kg
+                    * self.props.a_grav_mps2
+                    * self.veh.wheel_rr_coef
+                    * grade.atan().cos()
+                    * self.mps_ach[i - 1];
+                let ascent0 = 0.5
+                    * self.props.a_grav_mps2
+                    * grade.atan().sin()
+                    * self.veh.veh_kg
+                    * self.mps_ach[i - 1];
+                let wheel0 = -0.5
+                    * self.veh.wheel_inertia_kg_m2
+                    * self.veh.num_wheels
+                    * self.mps_ach[i - 1].powf(2.0)
+                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powf(2.0));
 
+                let total3 = drag3 / 1e3;
+                let total2 = (accel2 + drag2 + wheel2) / 1e3;
+                let total1 = (drag1 + roll1 + ascent1) / 1e3;
+                let total0 = (accel0 + drag0 + roll0 + ascent0 + wheel0) / 1e3
+                    - self.cur_max_trans_kw_out[i];
+
+                let totals = array![total3, total2, total1, total0];
+
+                let t3 = totals[0];
+                let t2 = totals[1];
+                let t1 = totals[2];
+                let t0 = totals[3];
                 // initial guess
                 let xi = max(1.0, self.mps_ach[i - 1]);
                 // stop criteria

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -862,10 +862,10 @@ impl RustSimDrive {
             * self.props.air_density_kg_per_m3
             * self.veh.drag_coef
             * self.veh.frontal_area_m2
-            * ((self.mps_ach[i - 1] + mps_ach) / 2.0).powf(3.0)
+            * ((self.mps_ach[i - 1] + mps_ach) / 2.0).powi(3)
             / 1e3;
         self.accel_kw[i] = self.veh.veh_kg / (2.0 * self.cyc.dt_s_at_i(i))
-            * (mps_ach.powf(2.0) - self.mps_ach[i - 1].powf(2.0))
+            * (mps_ach.powi(2) - self.mps_ach[i - 1].powi(2))
             / 1e3;
         self.ascent_kw[i] = self.props.a_grav_mps2
             * grade.atan().sin()
@@ -886,12 +886,12 @@ impl RustSimDrive {
         self.cyc_tire_inertia_kw[i] = (0.5
             * self.veh.wheel_inertia_kg_m2
             * self.veh.num_wheels
-            * self.cyc_whl_rad_per_sec[i].powf(2.0)
+            * self.cyc_whl_rad_per_sec[i].powi(2)
             / self.cyc.dt_s_at_i(i)
             - 0.5
                 * self.veh.wheel_inertia_kg_m2
                 * self.veh.num_wheels
-                * (self.mps_ach[i - 1] / self.veh.wheel_radius_m).powf(2.0)
+                * (self.mps_ach[i - 1] / self.veh.wheel_radius_m).powi(2)
                 / self.cyc.dt_s_at_i(i))
             / 1e3;
 
@@ -978,12 +978,12 @@ impl RustSimDrive {
                     * self.veh.frontal_area_m2
                     * self.mps_ach[i - 1];
                 let wheel2 = 0.5 * self.veh.wheel_inertia_kg_m2 * self.veh.num_wheels
-                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powf(2.0));
+                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powi(2));
                 let drag1 = 3.0 / 16.0
                     * self.props.air_density_kg_per_m3
                     * self.veh.drag_coef
                     * self.veh.frontal_area_m2
-                    * self.mps_ach[i - 1].powf(2.0);
+                    * self.mps_ach[i - 1].powi(2);
                 let roll1 = 0.5
                     * self.veh.veh_kg
                     * self.props.a_grav_mps2
@@ -991,12 +991,12 @@ impl RustSimDrive {
                     * grade.atan().cos();
                 let ascent1 = 0.5 * self.props.a_grav_mps2 * grade.atan().sin() * self.veh.veh_kg;
                 let accel0 =
-                    -0.5 * self.veh.veh_kg * self.mps_ach[i - 1].powf(2.0) / self.cyc.dt_s_at_i(i);
+                    -0.5 * self.veh.veh_kg * self.mps_ach[i - 1].powi(2) / self.cyc.dt_s_at_i(i);
                 let drag0 = 1.0 / 16.0
                     * self.props.air_density_kg_per_m3
                     * self.veh.drag_coef
                     * self.veh.frontal_area_m2
-                    * self.mps_ach[i - 1].powf(3.0);
+                    * self.mps_ach[i - 1].powi(3);
                 let roll0 = 0.5
                     * self.veh.veh_kg
                     * self.props.a_grav_mps2
@@ -1011,8 +1011,8 @@ impl RustSimDrive {
                 let wheel0 = -0.5
                     * self.veh.wheel_inertia_kg_m2
                     * self.veh.num_wheels
-                    * self.mps_ach[i - 1].powf(2.0)
-                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powf(2.0));
+                    * self.mps_ach[i - 1].powi(2)
+                    / (self.cyc.dt_s_at_i(i) * self.veh.wheel_radius_m.powi(2));
 
                 let t3 = drag3 / 1e3;
                 let t2 = (accel2 + drag2 + wheel2) / 1e3;
@@ -1028,10 +1028,10 @@ impl RustSimDrive {
                 // solver gain
                 let g = self.sim_params.newton_gain;
                 let pwr_err_fn = |speed_guess: f64| -> f64 {
-                    t3 * speed_guess.powf(3.0) + t2 * speed_guess.powf(2.0) + t1 * speed_guess + t0
+                    t3 * speed_guess.powi(3) + t2 * speed_guess.powi(2) + t1 * speed_guess + t0
                 };
                 let pwr_err_per_speed_guess_fn = |speed_guess: f64| -> f64 {
-                    3.0 * t3 * speed_guess.powf(2.0) + 2.0 * t2 * speed_guess + t1
+                    3.0 * t3 * speed_guess.powi(2) + 2.0 * t2 * speed_guess + t1
                 };
                 let pwr_err = pwr_err_fn(speed_guess);
                 let pwr_err_per_speed_guess = pwr_err_per_speed_guess_fn(speed_guess);
@@ -1113,7 +1113,7 @@ impl RustSimDrive {
                 (self.veh.ess_max_kwh * self.veh.max_soc
                     - 0.5
                         * self.veh.veh_kg
-                        * (self.cyc.mps[i].powf(2.0))
+                        * (self.cyc.mps[i].powi(2))
                         * (1.0 / 1_000.0)
                         * (1.0 / 3_600.0)
                         * self.veh.mc_peak_eff()
@@ -1145,9 +1145,9 @@ impl RustSimDrive {
         } else {
             self.accel_buff_soc[i] = min(
                 max(
-                    ((self.veh.max_accel_buffer_mph / params::MPH_PER_MPS).powf(2.0)
-                        - self.cyc.mps[i].powf(2.0))
-                        / (self.veh.max_accel_buffer_mph / params::MPH_PER_MPS).powf(2.0)
+                    ((self.veh.max_accel_buffer_mph / params::MPH_PER_MPS).powi(2)
+                        - self.cyc.mps[i].powi(2))
+                        / (self.veh.max_accel_buffer_mph / params::MPH_PER_MPS).powi(2)
                         * min(
                             self.veh.max_accel_buffer_perc_of_useable_soc
                                 * (self.veh.max_soc - self.veh.min_soc),
@@ -1849,12 +1849,12 @@ impl RustSimDrive {
                 .mps_ach
                 .first()
                 .ok_or_else(|| anyhow!(format_dbg!(self.mps_ach)))?
-                .powf(2.0)
+                .powi(2)
                 - self
                     .mps_ach
                     .last()
                     .ok_or_else(|| anyhow!(format_dbg!(self.mps_ach)))?
-                    .powf(2.0))
+                    .powi(2))
             / 1_000.0;
 
         self.energy_audit_error =
@@ -1870,7 +1870,7 @@ impl RustSimDrive {
         }
         for i in 1..self.cyc.len() {
             self.accel_kw[i] = self.veh.veh_kg / (2.0 * self.cyc.dt_s_at_i(i))
-                * (self.mps_ach[i].powf(2.0) - self.mps_ach[i - 1].powf(2.0))
+                * (self.mps_ach[i].powi(2) - self.mps_ach[i - 1].powi(2))
                 / 1_000.0;
         }
 

--- a/rust/fastsim-core/src/simdrivelabel.rs
+++ b/rust/fastsim-core/src/simdrivelabel.rs
@@ -803,7 +803,12 @@ mod simdrivelabel_tests {
         //     100. * (label_fe_truth.net_accel - label_fe.net_accel) / label_fe_truth.net_accel
         // );
 
-        assert!(label_fe.approx_eq(&label_fe_truth, 1e-10));
+        assert!(
+            label_fe.approx_eq(&label_fe_truth, 1e-10),
+            "label_fe:\n{}\n\nlabel_fe_truth:\n{}",
+            label_fe.to_json(),
+            label_fe_truth.to_json()
+        );
     }
     #[test]
     fn test_get_label_fe_phev() {


### PR DESCRIPTION
Implemented the following in https://github.com/NREL/fastsim/blob/0a4b848acaf2a672d93d8d8dfd495415311757f8/rust/fastsim-core/src/simdrive/simdrive_impl.rs#L953
- more descriptive variable names
- use of closures to reduce redundancy

I did this to make it easier to see how to write this section in `fastsim-3`.  