### PR TITLE
Use ndarray stats

### DIFF
--- a/rust/fastsim-core/Cargo.toml
+++ b/rust/fastsim-core/Cargo.toml
@@ -33,6 +33,7 @@ lazy_static = "1.4.0"
 regex = "1.7.1"
 rayon = "1.7.0"
 include_dir = "0.7.3"
+ndarray-stats = "0.5.1"
 
 [package.metadata]
 include = [

--- a/rust/fastsim-core/src/imports.rs
+++ b/rust/fastsim-core/src/imports.rs
@@ -2,6 +2,7 @@ pub(crate) use anyhow::{anyhow, bail, ensure, Context};
 pub(crate) use bincode;
 pub(crate) use log;
 pub(crate) use ndarray::{array, concatenate, s, Array, Array1, Axis};
+pub(crate) use ndarray_stats::QuantileExt;
 pub(crate) use serde::{Deserialize, Serialize};
 pub(crate) use std::cmp;
 pub(crate) use std::ffi::OsStr;

--- a/rust/fastsim-core/src/simdrive/cyc_mods.rs
+++ b/rust/fastsim-core/src/simdrive/cyc_mods.rs
@@ -8,7 +8,7 @@ use crate::cycle::{
     trapz_distance_for_step, trapz_step_distances, trapz_step_start_distance, PassingInfo,
 };
 use crate::simdrive::RustSimDrive;
-use crate::utils::{add_from, max, min, ndarrcumsum, ndarrmax, ndarrmin, ndarrunique};
+use crate::utils::{add_from, max, min, ndarrcumsum, ndarrunique};
 
 impl RustSimDrive {
     /// Provides the gap-with lead vehicle from start to finish
@@ -159,7 +159,7 @@ impl RustSimDrive {
         let v_desired_m_per_s = if self.idm_target_speed_m_per_s[i] > 0.0 {
             self.idm_target_speed_m_per_s[i]
         } else {
-            ndarrmax(&self.cyc0.mps)
+            *self.cyc0.mps.max().unwrap()
         };
         // DERIVED VALUES
         self.cyc.mps[i] = self.next_speed_by_idm(
@@ -902,8 +902,8 @@ impl RustSimDrive {
                         },
                     );
                 let accels_ndarr = Array1::from(accels_m_per_s2.clone());
-                let min_accel_m_per_s2 = ndarrmin(&accels_ndarr);
-                let max_accel_m_per_s2 = ndarrmax(&accels_ndarr);
+                let min_accel_m_per_s2 = accels_ndarr.min()?;
+                let max_accel_m_per_s2 = accels_ndarr.max()?;
                 let accept = all_sub_coast;
                 let accel_spread = (max_accel_m_per_s2 - min_accel_m_per_s2).abs();
                 if accept && (!best.found_trajectory || accel_spread < best.accel_spread) {

--- a/rust/fastsim-core/src/simdrive/simdrive_impl.rs
+++ b/rust/fastsim-core/src/simdrive/simdrive_impl.rs
@@ -4,7 +4,7 @@ use crate::cycle::{RustCycle, RustCycleCache};
 use crate::imports::*;
 use crate::params;
 use crate::simdrive::{RustSimDrive, RustSimDriveParams};
-use crate::utils::{arrmax, first_grtr, max, min, ndarrmax, ndarrmin};
+use crate::utils::{arrmax, first_grtr, max, min};
 use crate::vehicle::*;
 
 pub struct RendezvousTrajectory {
@@ -511,12 +511,12 @@ impl RustSimDrive {
             if self.sim_params.missed_trace_correction {
                 log::info!(
                     "Max time dilation factor = {:.3}",
-                    ndarrmax(&(self.cyc.dt_s() / self.cyc0.dt_s()))
+                    (self.cyc.dt_s() / self.cyc0.dt_s()).max()?
                 );
             }
             log::warn!(
                 "Large time steps affect accuracy significantly (max time step = {:.3})",
-                ndarrmax(&self.cyc.dt_s())
+                self.cyc.dt_s().max()?
             );
         }
         Ok(())
@@ -1085,8 +1085,8 @@ impl RustSimDrive {
                 self.mps_ach[i] = max(
                     speed_guesses[_ys
                         .iter()
-                        .position(|&x| x == ndarrmin(&_ys))
-                        .ok_or_else(|| anyhow!(format_dbg!(ndarrmin(&_ys))))?],
+                        .position(|x| x == _ys.min().unwrap())
+                        .ok_or_else(|| anyhow!(format_dbg!(_ys.min().unwrap())))?],
                     0.0,
                 );
                 grade_estimate = self.lookup_grade_for_step(i, Some(self.mps_ach[i]));
@@ -1914,8 +1914,7 @@ impl RustSimDrive {
             );
         }
 
-        self.trace_miss_speed_mps =
-            ndarrmax(&(self.mps_ach.clone() - self.cyc.mps.clone()).map(|x| x.abs()));
+        self.trace_miss_speed_mps = *(&self.mps_ach - &self.cyc.mps).map(|x| x.abs()).max()?;
         if self.trace_miss_speed_mps > self.sim_params.trace_miss_speed_mps_tol {
             self.trace_miss = true;
             log::warn!(

--- a/rust/fastsim-core/src/simdrivelabel.rs
+++ b/rust/fastsim-core/src/simdrivelabel.rs
@@ -1,6 +1,7 @@
 //! Module containing classes and methods for calculating label fuel economy.
 
 use ndarray::Array;
+use ndarray_stats::QuantileExt;
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -501,7 +502,7 @@ pub fn get_label_fe_phev(
 
         // city and highway cycle ranges
         phev_calc.cd_miles =
-            if (veh.max_soc - phev_calcs.regen_soc_buffer - ndarrmin(&sd_val.soc)) < 0.01 {
+            if (veh.max_soc - phev_calcs.regen_soc_buffer - sd_val.soc.min()?) < 0.01 {
                 1000.0
             } else {
                 phev_calc.cd_cycs.ceil() * sd_val.dist_mi.sum()
@@ -517,7 +518,7 @@ pub fn get_label_fe_phev(
 
         // labCombMpgge
         phev_calc.cd_adj_mpg =
-            ndarrmax(&phev_calc.lab_iter_uf) / phev_calc.lab_uf_gpm[phev_calc.lab_uf_gpm.len() - 2];
+            phev_calc.lab_iter_uf.max()? / phev_calc.lab_uf_gpm[phev_calc.lab_uf_gpm.len() - 2];
 
         phev_calc.lab_mpgge = 1.0
             / (phev_calc.lab_uf / phev_calc.cd_adj_mpg
@@ -543,7 +544,7 @@ pub fn get_label_fe_phev(
         phev_calc.lab_iter_uf_kwh_per_mi = Array::from_vec(vals);
 
         phev_calc.lab_kwh_per_mi =
-            phev_calc.lab_iter_uf_kwh_per_mi.sum() / ndarrmax(&phev_calc.lab_iter_uf);
+            phev_calc.lab_iter_uf_kwh_per_mi.sum() / phev_calc.lab_iter_uf.max()?;
 
         let mut adj_iter_mpgge_vals: Vec<f64> = vec![0.0; phev_calc.cd_cycs.floor() as usize];
         let mut adj_iter_kwh_per_mi_vals: Vec<f64> = vec![0.0; phev_calc.lab_iter_kwh_per_mi.len()];
@@ -632,10 +633,10 @@ pub fn get_label_fe_phev(
         }
 
         phev_calc.adj_cd_miles =
-            if veh.max_soc - phev_calcs.regen_soc_buffer - ndarrmin(&sd_val.soc) < 0.01 {
+            if veh.max_soc - phev_calcs.regen_soc_buffer - sd_val.soc.min()? < 0.01 {
                 1000.0
             } else {
-                ndarrmax(&phev_calc.adj_iter_cd_miles)
+                *phev_calc.adj_iter_cd_miles.max()?
             };
 
         // utility factor calculation for last charge depletion iteration and transition iteration
@@ -664,9 +665,9 @@ pub fn get_label_fe_phev(
 
         phev_calc.adj_cd_mpgge = 1.0
             / phev_calc.adj_iter_uf_gpm[phev_calc.adj_iter_uf_gpm.len() - 2]
-            * ndarrmax(&phev_calc.adj_iter_uf);
+            * phev_calc.adj_iter_uf.max()?;
         phev_calc.adj_cs_mpgge = 1.0 / phev_calc.adj_iter_uf_gpm.last().unwrap()
-            * (1.0 - ndarrmax(&phev_calc.adj_iter_uf));
+            * (1.0 - phev_calc.adj_iter_uf.max()?);
 
         phev_calc.adj_uf = long_params.uf_array
             [first_grtr(&long_params.rechg_freq_miles, phev_calc.adj_cd_miles).unwrap() - 1];
@@ -676,10 +677,10 @@ pub fn get_label_fe_phev(
                 + (1.0 - phev_calc.adj_uf) / phev_calc.adj_cs_mpgge);
 
         phev_calc.adj_kwh_per_mi =
-            phev_calc.adj_iter_uf_kwh_per_mi.sum() / ndarrmax(&phev_calc.adj_iter_uf) / veh.chg_eff;
+            phev_calc.adj_iter_uf_kwh_per_mi.sum() / phev_calc.adj_iter_uf.max()? / veh.chg_eff;
 
         phev_calc.adj_ess_kwh_per_mi =
-            phev_calc.adj_iter_uf_kwh_per_mi.sum() / ndarrmax(&phev_calc.adj_iter_uf);
+            phev_calc.adj_iter_uf_kwh_per_mi.sum() / phev_calc.adj_iter_uf.max()?;
 
         match *key {
             "udds" => phev_calcs.udds = phev_calc.clone(),

--- a/rust/fastsim-core/src/thermal.rs
+++ b/rust/fastsim-core/src/thermal.rs
@@ -952,7 +952,7 @@ impl SimDriveHot {
                 }
             }
 
-            if self.sd.fc_kw_out_ach[i] == ndarrmax(&self.sd.veh.input_kw_out_array) {
+            if &self.sd.fc_kw_out_ach[i] == self.sd.veh.input_kw_out_array.max()? {
                 self.sd.fc_kw_in_ach[i] = self.sd.fc_kw_out_ach[i]
                     / (self.sd.veh.fc_eff_array.last().unwrap() * self.state.fc_eta_temp_coeff)
             } else {
@@ -963,7 +963,7 @@ impl SimDriveHot {
                             &self.sd.veh.fc_kw_out_array,
                             min(
                                 self.sd.fc_kw_out_ach[i],
-                                ndarrmax(&self.sd.veh.input_kw_out_array) - 0.001,
+                                self.sd.veh.input_kw_out_array.max()? - 0.001,
                             ),
                         )
                         .unwrap()

--- a/rust/fastsim-core/src/utils.rs
+++ b/rust/fastsim-core/src/utils.rs
@@ -1,6 +1,7 @@
 //! Module containing miscellaneous utility functions.
 
 use lazy_static::lazy_static;
+use ndarray_stats::QuantileExt;
 use regex::Regex;
 use std::collections::HashSet;
 
@@ -82,16 +83,6 @@ pub fn arrmin(arr: &[f64]) -> f64 {
     arr.iter().copied().fold(f64::NAN, f64::min)
 }
 
-/// return min of arr
-pub fn ndarrmin(arr: &Array1<f64>) -> f64 {
-    arr.to_vec().into_iter().reduce(f64::min).unwrap()
-}
-
-/// return max of arr
-pub fn ndarrmax(arr: &Array1<f64>) -> f64 {
-    arr.to_vec().into_iter().reduce(f64::max).unwrap()
-}
-
 /// return true if the array is all zeros
 pub fn ndarrallzeros(arr: &Array1<f64>) -> bool {
     arr.iter().all(|x| *x == 0.0)
@@ -111,8 +102,8 @@ pub fn ndarrcumsum(arr: &Array1<f64>) -> Array1<f64> {
 pub fn ndarrunique(arr: &Array1<f64>) -> Array1<f64> {
     let mut set: HashSet<usize> = HashSet::new();
     let mut new_arr: Vec<f64> = Vec::new();
-    let x_min = ndarrmin(arr);
-    let x_max = ndarrmax(arr);
+    let x_min = arr.min().unwrap();
+    let x_max = arr.max().unwrap();
     let dx = if x_max == x_min { 1.0 } else { x_max - x_min };
     for &x in arr.iter() {
         let y = (((x - x_min) / dx) * (usize::MAX as f64)) as usize;
@@ -544,20 +535,6 @@ mod tests {
         let idx = first_grtr(&xs, 7.0).unwrap();
         let expected_idx: usize = xs.len() - 1;
         assert_eq!(idx, expected_idx)
-    }
-
-    #[test]
-    fn test_that_ndarrmin_returns_the_min() {
-        let xs = Array1::from_vec(vec![10.0, 80.0, 3.0, 3.2, 9.0]);
-        let xmin = ndarrmin(&xs);
-        assert_eq!(xmin, 3.0);
-    }
-
-    #[test]
-    fn test_that_ndarrmax_returns_the_max() {
-        let xs = Array1::from_vec(vec![10.0, 80.0, 3.0, 3.2, 9.0]);
-        let xmax = ndarrmax(&xs);
-        assert_eq!(xmax, 80.0);
     }
 
     #[test]

--- a/rust/fastsim-core/src/vehicle.rs
+++ b/rust/fastsim-core/src/vehicle.rs
@@ -626,7 +626,7 @@ impl RustVehicle {
     }
 
     pub fn set_mc_peak_eff(&mut self, new_peak: f64) {
-        let mc_max_eff = ndarrmax(&self.mc_eff_array);
+        let mc_max_eff = self.mc_eff_array.max().unwrap();
         self.mc_eff_array *= new_peak / mc_max_eff;
         let mc_max_full_eff = arrmax(&self.mc_full_eff_array);
         self.mc_full_eff_array = self


### PR DESCRIPTION
This PR eliminates `ndarrmax` and `ndarrmin` and instead uses the methods implemented by [ndarray_stats::QuantileExt](https://docs.rs/ndarray-stats/latest/ndarray_stats/trait.QuantileExt.html)

For example:
```diff
- let mc_max_eff = ndarrmax(&self.mc_eff_array);
+ let mc_max_eff = self.mc_eff_array.max().unwrap();
```