### PR TITLE
GitHub Action for Building CLI Programs

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -77,5 +77,4 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cli
           path: ./cli

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -5,8 +5,6 @@ on:
     tags:
       # 'v[0-9]+.[0-9]+.[0-9]+' to match semantic version tag, e.g. v2.0.8
       - "v[0-9]+.[0-9]+.[0-9]+"
-    branches:
-      - feature/github-action-for-cli
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -56,8 +56,8 @@ jobs:
 
       - run: cd rust/ && cargo test
 
-      - name: list dist files
-        run: ${{ matrix.ls || 'ls -lh' }} dist/
+      - name: list current directory files
+        run: ${{ matrix.ls || 'ls -lh' }} .
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -56,8 +56,10 @@ jobs:
 
       - run: cd rust/ && cargo test
 
+      - run: cd rust/ && cargo build --release
+
       - name: list current directory files
-        run: ${{ matrix.ls || 'ls -lh' }} .
+        run: ${{ matrix.ls || 'ls -lh' }} ./rust/target/release/
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -1,4 +1,4 @@
-name: cli-app-build
+name: build-cli
 
 on:
   push:
@@ -24,6 +24,7 @@ jobs:
             ls: dir
 
     runs-on: ${{ format('{0}-latest', matrix.os) }}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -32,9 +33,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable 
+          toolchain: stable
           override: true
-      
+
       - name: set up rust for ubuntu
         if: matrix.os == 'ubuntu'
         run: >
@@ -48,7 +49,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable 
+          toolchain: stable
           override: true
 
       - run: cd rust/ && cargo test

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -54,13 +54,27 @@ jobs:
           toolchain: stable
           override: true
 
-      - run: cd rust/ && cargo test
+      - run: cd rust/fastsim-cli/ && cargo test
 
-      - run: cd rust/ && cargo build --release
+      - run: cd rust/fastsim-cli/ && cargo build --release
 
       - name: list current directory files
         run: ${{ matrix.ls || 'ls -lh' }} ./rust/target/release/
+      
+      - name: copy cli programs to new directory
+        if: matrix.os == 'windows'
+        run: |
+          mkdir cli
+          copy ./rust/target/release/vehicle-import-cli.exe cli
+          copy ./rust/target/release/fastsim-cli.exe cli
+      
+      - name: copy cli programs to new directory (non-windows)
+        if: matrix.os != 'windows'
+        run: |
+          mkdir cli
+          cp ./rust/target/release/vehicle-import-cli cli
+          cp ./rust/target/release/fastsim-cli cli
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./rust/target/release/
+          path: ./cli

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -75,6 +75,7 @@ jobs:
           cp ./rust/target/release/vehicle-import-cli cli
           cp ./rust/target/release/fastsim-cli cli
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cli
           path: ./cli

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -61,4 +61,4 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./target/release/
+          path: ./rust/target/release/

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -1,10 +1,8 @@
 name: build-cli
 
 on:
-  push:
-    tags:
-      # 'v[0-9]+.[0-9]+.[0-9]+' to match semantic version tag, e.g. v2.0.8
-      - "v[0-9]+.[0-9]+.[0-9]+"
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -77,4 +77,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.os }}-cli
           path: ./cli

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       # 'v[0-9]+.[0-9]+.[0-9]+' to match semantic version tag, e.g. v2.0.8
       - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - feature/github-action-for-cli
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cli-app-build.yaml
+++ b/.github/workflows/cli-app-build.yaml
@@ -1,4 +1,4 @@
-name: wheels
+name: cli-app-build
 
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
       
       - name: set up rust for ubuntu
         if: matrix.os == 'ubuntu'
-        bash: >
+        run: >
           curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=nightly --profile=minimal -y &&
           rustup show
 
@@ -52,47 +52,6 @@ jobs:
           override: true
 
       - run: cd rust/ && cargo test
-
-      - name: build ${{ matrix.platform || matrix.os }} binaries
-        run: cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
-          CIBW_SKIP: "*-win32 *-musllinux* *i686 *ppc64le *s390x *aarch64"
-          CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}
-          # TODO: why doesn't pytest work with cibuildwheel?
-          # CIBW_TEST_COMMAND: "pytest -v {project}/python/fastsim/tests"
-          CIBW_TEST_COMMAND: "python -m unittest discover {project}/python/fastsim/tests"
-          CIBW_ARCHS_MACOS: 'universal2'
-          # see https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2
-          CIBW_TEST_SKIP: '*_universal2:arm64'
-          CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
-          CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
-          CIBW_MANYLINUX_I686_IMAGE: "manylinux2014"
-          CIBW_BEFORE_BUILD: >
-            pip install -U setuptools-rust &&
-            rustup default stable &&
-            rustup show
-          CIBW_BEFORE_BUILD_LINUX: >
-            pip install -U setuptools-rust &&
-            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=nightly --profile=minimal -y &&
-            rustup show
-
-      # - name: build windows 32bit binaries
-      #   if: matrix.os == 'windows'
-      #   run: cibuildwheel --output-dir dist
-      #   env:
-      #     CIBW_BUILD: 'cp3${{ matrix.python-version }}-win32'
-      #     CIBW_PLATFORM: windows
-      #     CIBW_TEST_REQUIRES: 'pytest'
-      #     CIBW_TEST_COMMAND: 'pytest {project}/tests -s'
-      #     CIBW_ENVIRONMENT: 'PATH="$UserProfile\.cargo\bin;$PATH"'
-      #     CIBW_BEFORE_BUILD: >
-      #       pip install -U setuptools-rust &&
-      #       rustup toolchain install nightly-i686-pc-windows-msvc &&
-      #       rustup default nightly-i686-pc-windows-msvc &&
-      #       rustup override set nightly-i686-pc-windows-msvc &&
-      #       rustup show
 
       - name: list dist files
         run: ${{ matrix.ls || 'ls -lh' }} dist/

--- a/.github/workflows/cli-app-build.yaml
+++ b/.github/workflows/cli-app-build.yaml
@@ -1,0 +1,102 @@
+name: wheels
+
+on:
+  push:
+    tags:
+      # 'v[0-9]+.[0-9]+.[0-9]+' to match semantic version tag, e.g. v2.0.8
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build command line interfaces for ${{ matrix.platform || matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
+        include:
+          - os: ubuntu
+            platform: linux
+          - os: windows
+            ls: dir
+
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: set up rust
+        if: matrix.os != 'ubuntu'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable 
+          override: true
+      
+      - name: set up rust for ubuntu
+        if: matrix.os == 'ubuntu'
+        bash: >
+          curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=nightly --profile=minimal -y &&
+          rustup show
+
+      - run: rustup target add aarch64-apple-darwin
+        if: matrix.os == 'macos'
+
+      - name: run cargo tests
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable 
+          override: true
+
+      - run: cd rust/ && cargo test
+
+      - name: build ${{ matrix.platform || matrix.os }} binaries
+        run: cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
+          CIBW_SKIP: "*-win32 *-musllinux* *i686 *ppc64le *s390x *aarch64"
+          CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}
+          # TODO: why doesn't pytest work with cibuildwheel?
+          # CIBW_TEST_COMMAND: "pytest -v {project}/python/fastsim/tests"
+          CIBW_TEST_COMMAND: "python -m unittest discover {project}/python/fastsim/tests"
+          CIBW_ARCHS_MACOS: 'universal2'
+          # see https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2
+          CIBW_TEST_SKIP: '*_universal2:arm64'
+          CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
+          CIBW_ENVIRONMENT_WINDOWS: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
+          CIBW_MANYLINUX_I686_IMAGE: "manylinux2014"
+          CIBW_BEFORE_BUILD: >
+            pip install -U setuptools-rust &&
+            rustup default stable &&
+            rustup show
+          CIBW_BEFORE_BUILD_LINUX: >
+            pip install -U setuptools-rust &&
+            curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain=nightly --profile=minimal -y &&
+            rustup show
+
+      # - name: build windows 32bit binaries
+      #   if: matrix.os == 'windows'
+      #   run: cibuildwheel --output-dir dist
+      #   env:
+      #     CIBW_BUILD: 'cp3${{ matrix.python-version }}-win32'
+      #     CIBW_PLATFORM: windows
+      #     CIBW_TEST_REQUIRES: 'pytest'
+      #     CIBW_TEST_COMMAND: 'pytest {project}/tests -s'
+      #     CIBW_ENVIRONMENT: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+      #     CIBW_BEFORE_BUILD: >
+      #       pip install -U setuptools-rust &&
+      #       rustup toolchain install nightly-i686-pc-windows-msvc &&
+      #       rustup default nightly-i686-pc-windows-msvc &&
+      #       rustup override set nightly-i686-pc-windows-msvc &&
+      #       rustup show
+
+      - name: list dist files
+        run: ${{ matrix.ls || 'ls -lh' }} dist/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./target/release/


### PR DESCRIPTION
Reference from issue https://github.nrel.gov/MBAP/fastsim/issues/231

This adds build support for building the command line interface programs in the package. You can check the artifacts under the Actions and `build-cli` task above to test out the built artifacts (I've only tested the Windows versions thus far).