### PR TITLE
from_resource now calls from_reader

### DIFF
--- a/rust/fastsim-core/src/cycle.rs
+++ b/rust/fastsim-core/src/cycle.rs
@@ -715,11 +715,11 @@ impl SerdeAPI for RustCycle {
 
     /// Note that using this method to instantiate a RustCycle from CSV, rather
     /// than the `from_csv_str` method, sets the cycle name to an empty string
-    fn from_str(contents: &str, format: &str) -> anyhow::Result<Self> {
+    fn from_str<S: AsRef<str>>(contents: S, format: &str) -> anyhow::Result<Self> {
         match format.trim_start_matches('.').to_lowercase().as_str() {
             "yaml" | "yml" => Self::from_yaml(contents),
             "json" => Self::from_json(contents),
-            "csv" => Self::from_csv_str(contents, ""),
+            "csv" => Self::from_csv_str(contents, "".to_string()),
             _ => bail!(
                 "Unsupported format {format:?}, must be one of {:?}",
                 Self::ACCEPTED_STR_FORMATS
@@ -802,9 +802,9 @@ impl RustCycle {
     }
 
     /// Load cycle from CSV string
-    pub fn from_csv_str(csv_str: &str, name: &str) -> anyhow::Result<Self> {
-        let mut cyc = Self::from_reader(csv_str.as_bytes(), "csv")?;
-        cyc.name = name.to_string();
+    pub fn from_csv_str<S: AsRef<str>>(csv_str: S, name: String) -> anyhow::Result<Self> {
+        let mut cyc = Self::from_reader(csv_str.as_ref().as_bytes(), "csv")?;
+        cyc.name = name;
         Ok(cyc)
     }
 
@@ -1238,10 +1238,10 @@ mod tests {
 
     #[test]
     fn test_str_serde() {
-        let format = "csv";
         let cyc = RustCycle::test_cyc();
-        println!("{cyc:?}");
-        let csv_str = cyc.to_str(format).unwrap();
-        RustCycle::from_str(&csv_str, format).unwrap();
+        for format in RustCycle::ACCEPTED_STR_FORMATS {
+            let csv_str = cyc.to_str(format).unwrap();
+            RustCycle::from_str(&csv_str, format).unwrap();
+        }
     }
 }

--- a/rust/fastsim-core/src/traits.rs
+++ b/rust/fastsim-core/src/traits.rs
@@ -69,22 +69,10 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
             .and_then(OsStr::to_str)
             .with_context(|| format!("File extension could not be parsed: {filepath:?}"))?
             .to_lowercase();
-        ensure!(
-            Self::ACCEPTED_BYTE_FORMATS.contains(&extension.as_str()),
-            "Unsupported format {extension:?}, must be one of {:?}",
-            Self::ACCEPTED_BYTE_FORMATS
-        );
         let file = crate::resources::RESOURCES_DIR
             .get_file(filepath)
             .with_context(|| format!("File not found in resources: {filepath:?}"))?;
-        let mut deserialized = match extension.as_str() {
-            "bin" => Self::from_bincode(include_dir::File::contents(file))?,
-            _ => Self::from_str(
-                include_dir::File::contents_utf8(file)
-                    .with_context(|| format!("File could not be parsed to UTF-8: {filepath:?}"))?,
-                &extension,
-            )?,
-        };
+        let mut deserialized = Self::from_reader(file.contents(), &extension)?;
         deserialized.init()?;
         Ok(deserialized)
     }
@@ -114,7 +102,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
         }
     }
 
-    fn from_str(contents: &str, format: &str) -> anyhow::Result<Self> {
+    fn from_str<S: AsRef<str>>(contents: S, format: &str) -> anyhow::Result<Self> {
         match format.trim_start_matches('.').to_lowercase().as_str() {
             "yaml" | "yml" => Self::from_yaml(contents),
             "json" => Self::from_json(contents),
@@ -131,8 +119,8 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
     }
 
     /// JSON deserialization method
-    fn from_json(json_str: &str) -> anyhow::Result<Self> {
-        Ok(serde_json::from_str(json_str)?)
+    fn from_json<S: AsRef<str>>(json_str: S) -> anyhow::Result<Self> {
+        Ok(serde_json::from_str(json_str.as_ref())?)
     }
 
     /// YAML serialization method
@@ -141,8 +129,8 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> {
     }
 
     /// YAML deserialization method
-    fn from_yaml(yaml_str: &str) -> anyhow::Result<Self> {
-        Ok(serde_yaml::from_str(yaml_str)?)
+    fn from_yaml<S: AsRef<str>>(yaml_str: S) -> anyhow::Result<Self> {
+        Ok(serde_yaml::from_str(yaml_str.as_ref())?)
     }
 
     /// bincode serialization method


### PR DESCRIPTION
Also `from_csv_str` now takes `name: String`, which is totally fine as it allocates anyway, so the allocation happens explicitly within the caller rather than (possibly) multiple times.