### PR TITLE
implement to_writer method and clean up RustCycle csv serde

### DIFF
--- a/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
+++ b/rust/fastsim-core/fastsim-proc-macros/src/add_pyo3_api/mod.rs
@@ -215,8 +215,8 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_resource")]
-        pub fn from_resource_py(filepath: &PyAny) -> anyhow::Result<Self> {
-            Self::from_resource(PathBuf::extract(filepath)?)
+        pub fn from_resource_py(filepath: &PyAny) -> PyResult<Self> {
+            Self::from_resource(PathBuf::extract(filepath)?).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Write (serialize) an object to a file.
@@ -228,8 +228,8 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         /// * `filepath`: `str | pathlib.Path` - The filepath at which to write the object
         ///
         #[pyo3(name = "to_file")]
-        pub fn to_file_py(&self, filepath: &PyAny) -> anyhow::Result<()> {
-           self.to_file(PathBuf::extract(filepath)?)
+        pub fn to_file_py(&self, filepath: &PyAny) -> PyResult<()> {
+           self.to_file(PathBuf::extract(filepath)?).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Read (deserialize) an object from a file.
@@ -241,8 +241,8 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_file")]
-        pub fn from_file_py(filepath: &PyAny) -> anyhow::Result<Self> {
-            Self::from_file(PathBuf::extract(filepath)?)
+        pub fn from_file_py(filepath: &PyAny) -> PyResult<Self> {
+            Self::from_file(PathBuf::extract(filepath)?).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Write (serialize) an object into a string
@@ -252,8 +252,8 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         /// * `format`: `str` - The target format, any of those listed in [`ACCEPTED_STR_FORMATS`](`SerdeAPI::ACCEPTED_STR_FORMATS`)
         ///
         #[pyo3(name = "to_str")]
-        pub fn to_str_py(&self, format: &str) -> anyhow::Result<String> {
-            self.to_str(format)
+        pub fn to_str_py(&self, format: &str) -> PyResult<String> {
+            self.to_str(format).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Read (deserialize) an object from a string
@@ -265,14 +265,14 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_str")]
-        pub fn from_str_py(contents: &str, format: &str) -> anyhow::Result<Self> {
-            Self::from_str(contents, format)
+        pub fn from_str_py(contents: &str, format: &str) -> PyResult<Self> {
+            Self::from_str(contents, format).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Write (serialize) an object to a JSON string
         #[pyo3(name = "to_json")]
-        pub fn to_json_py(&self) -> anyhow::Result<String> {
-            self.to_json()
+        pub fn to_json_py(&self) -> PyResult<String> {
+            self.to_json().map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Read (deserialize) an object to a JSON string
@@ -283,14 +283,14 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_json")]
-        pub fn from_json_py(json_str: &str) -> anyhow::Result<Self> {
-            Self::from_json(json_str)
+        pub fn from_json_py(json_str: &str) -> PyResult<Self> {
+            Self::from_json(json_str).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Write (serialize) an object to a YAML string
         #[pyo3(name = "to_yaml")]
-        pub fn to_yaml_py(&self) -> anyhow::Result<String> {
-            self.to_yaml()
+        pub fn to_yaml_py(&self) -> PyResult<String> {
+            self.to_yaml().map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Read (deserialize) an object from a YAML string
@@ -301,14 +301,14 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_yaml")]
-        pub fn from_yaml_py(yaml_str: &str) -> anyhow::Result<Self> {
-            Self::from_yaml(yaml_str)
+        pub fn from_yaml_py(yaml_str: &str) -> PyResult<Self> {
+            Self::from_yaml(yaml_str).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Write (serialize) an object to bincode-encoded `bytes`
         #[pyo3(name = "to_bincode")]
-        pub fn to_bincode_py<'py>(&self, py: Python<'py>) -> anyhow::Result<&'py PyBytes> {
-            Ok(PyBytes::new(py, &self.to_bincode()?))
+        pub fn to_bincode_py<'py>(&self, py: Python<'py>) -> PyResult<&'py PyBytes> {
+            PyResult::Ok(PyBytes::new(py, &self.to_bincode()?)).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
         /// Read (deserialize) an object from bincode-encoded `bytes`
@@ -319,8 +319,8 @@ pub fn add_pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         #[staticmethod]
         #[pyo3(name = "from_bincode")]
-        pub fn from_bincode_py(encoded: &PyBytes) -> anyhow::Result<Self> {
-            Self::from_bincode(encoded.as_bytes())
+        pub fn from_bincode_py(encoded: &PyBytes) -> PyResult<Self> {
+            Self::from_bincode(encoded.as_bytes()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
     });
 

--- a/rust/fastsim-core/src/cycle.rs
+++ b/rust/fastsim-core/src/cycle.rs
@@ -798,14 +798,7 @@ impl RustCycle {
             .and_then(OsStr::to_str)
             .with_context(|| format!("Could not parse cycle name from filepath: {filepath:?}"))?
             .to_string();
-        let file = File::open(filepath).with_context(|| {
-            if !filepath.exists() {
-                format!("File not found: {filepath:?}")
-            } else {
-                format!("Could not open file: {filepath:?}")
-            }
-        })?;
-        let mut cyc = Self::from_reader(file, "csv")?;
+        let mut cyc = Self::from_file(filepath)?;
         cyc.name = name;
         Ok(cyc)
     }

--- a/rust/fastsim-core/src/cycle.rs
+++ b/rust/fastsim-core/src/cycle.rs
@@ -703,7 +703,7 @@ impl SerdeAPI for RustCycle {
             match format.trim_start_matches('.').to_lowercase().as_str() {
                 "yaml" | "yml" => Self::from_yaml(contents)?,
                 "json" => Self::from_json(contents)?,
-                "csv" => Self::from_csv_str(contents, "".to_string())?,
+                "csv" => Self::from_reader(contents.as_ref().as_bytes(), "csv")?,
                 _ => bail!(
                     "Unsupported format {format:?}, must be one of {:?}",
                     Self::ACCEPTED_STR_FORMATS
@@ -805,7 +805,7 @@ impl RustCycle {
 
     /// Load cycle from CSV string
     pub fn from_csv_str<S: AsRef<str>>(csv_str: S, name: String) -> anyhow::Result<Self> {
-        let mut cyc = Self::from_reader(csv_str.as_ref().as_bytes(), "csv")?;
+        let mut cyc = Self::from_str(csv_str, "csv")?;
         cyc.name = name;
         Ok(cyc)
     }


### PR DESCRIPTION
- adds a `to_writer` method
  - RustCycle just needs to override `to_writer` instead of `to_file`
  - Cleanup/reorg of SerdeAPI-alike functions in RustCycle (`write_csv` etc)
  - New `RustCycle::to_csv` function to be consistent with `to_yaml` etc, same functionality as `RustCycle::to_str("csv")` (which now calls `RustCycle::to_csv`)
- All SerdeAPI errors are now exposed as `IOError`/`OSError` in Python rather than `RuntimeError`

I noticed the Python-exposed `RustCycle::from_csv` loads a cycle from a given filepath, rather than a string like `from_yaml`, `from_json`, etc. I think this is something that I would definitely want to change in FASTSim 3. @calbaker what are your thoughts about making all these string deserialization methods have `_str` at the end (starting in FASTSim 3, to avoid API changes)?

i.e. `from_yaml` would become `from_yaml_str` to make it clear that it takes a YAML-formatted string, rather than a filepath