### PR TITLE
updates the fastsim-2 demo files to run Rust instead of Python

### DIFF
--- a/python/fastsim/demos/demo.py
+++ b/python/fastsim/demos/demo.py
@@ -642,7 +642,9 @@ microtrips = fsim.cycle.to_microtrips(cyc.to_dict())
 cyc = fsim.cycle.Cycle.from_dict(microtrips[1])
 print(f'Time to load cycle: {time.perf_counter() - t0:.2e} s')
 
-
+# None of the instances of sim_drive() called past this point have a rust
+# version, only python. Should these be switched to rust, or are they called in
+# python on purpose?
 # %% simulate
 t0 = time.perf_counter()
 sim_drive = fsim.simdrive.SimDrive(cyc, veh)

--- a/python/fastsim/demos/demo_eu_vehicle_wltp.py
+++ b/python/fastsim/demos/demo_eu_vehicle_wltp.py
@@ -65,6 +65,7 @@ def hybrid_eu_veh_wltp_fe_test():
 
     sim = fsim.simdrive.SimDrive(cyc_wltp_combined, veh_2022_yaris)
     sim_rust = fsim.simdrive.RustSimDrive(cyc_wltp_combined_rust,veh_2022_yaris_rust)
+    # In this case, is sim_drive() run separately with python and rust for a reason?
     sim.sim_drive()
     sim_rust.sim_drive()
     

--- a/python/fastsim/demos/demo_eu_vehicle_wltp.py
+++ b/python/fastsim/demos/demo_eu_vehicle_wltp.py
@@ -42,8 +42,7 @@ def convention_eu_veh_wltp_fe_test():
 def hybrid_eu_veh_wltp_fe_test():
     WILLANS_FACTOR_gram_CO2__MJ = 724  # gCO2/MJ
     E10_HEAT_VALUE_kWh__liter = 8.64  # kWh/L
-    veh_2022_yaris = fsim.vehicle.Vehicle.from_file('2022_TOYOTA_Yaris_Hybrid_Mid.csv')
-    veh_2022_yaris_rust = fsim.vehicle.Vehicle.from_file('2022_TOYOTA_Yaris_Hybrid_Mid.csv', to_rust=True).to_rust()
+    veh_2022_yaris = fsim.vehicle.Vehicle.from_file('2022_TOYOTA_Yaris_Hybrid_Mid.csv', to_rust=True).to_rust()
     
     # Measured FE (L/100km)
     meas_fe_combined_liter__100km = 3.8
@@ -52,34 +51,22 @@ def hybrid_eu_veh_wltp_fe_test():
     meas_fe_high_liter__100km = 3.5
     meas_fe_extrahigh_liter__100km = 5
     
-    wltp_low_cyc_3 = fsim.cycle.Cycle.from_file('wltc_low_3.csv')
-    wltp_low_cyc_3_rust = wltp_low_cyc_3.to_rust()
-    wltp_med_cyc_3b = fsim.cycle.Cycle.from_file('wltc_medium_3b.csv')
-    wltp_med_cyc_3b_rust = wltp_med_cyc_3b.to_rust()
-    wltp_high_cyc_3b = fsim.cycle.Cycle.from_file('wltc_high_3b.csv')
-    wltp_high_cyc_3b_rust = wltp_high_cyc_3b.to_rust()
-    wltp_extrahigh_cyc_3 = fsim.cycle.Cycle.from_file('wltc_extrahigh_3.csv')
-    wltp_extrahigh_cyc_3_rust = wltp_extrahigh_cyc_3.to_rust()
-    cyc_wltp_combined = fsim.cycle.Cycle.from_file("wltc_3b.csv")
-    cyc_wltp_combined_rust = cyc_wltp_combined.to_rust()
+    wltp_low_cyc_3 = fsim.cycle.Cycle.from_file('wltc_low_3.csv').to_rust()
+    wltp_med_cyc_3b = fsim.cycle.Cycle.from_file('wltc_medium_3b.csv').to_rust()
+    wltp_high_cyc_3b = fsim.cycle.Cycle.from_file('wltc_high_3b.csv').to_rust()
+    wltp_extrahigh_cyc_3 = fsim.cycle.Cycle.from_file('wltc_extrahigh_3.csv').to_rust()
+    cyc_wltp_combined = fsim.cycle.Cycle.from_file("wltc_3b.csv").to_rust()
 
-    sim = fsim.simdrive.SimDrive(cyc_wltp_combined, veh_2022_yaris)
-    sim_rust = fsim.simdrive.RustSimDrive(cyc_wltp_combined_rust,veh_2022_yaris_rust)
-    # In this case, is sim_drive() run separately with python and rust for a reason?
+    sim = fsim.simdrive.RustSimDrive(cyc_wltp_combined, veh_2022_yaris)
     sim.sim_drive()
-    sim_rust.sim_drive()
     
-    dist_miles_combined = sim.dist_mi.sum()
-    dist_miles_combined_rust = sum(sim_rust.dist_mi)
-    print(f"Distance modelled in miles: Pure Python FastSim:\t{dist_miles_combined:.2f}\t Rust backend FastSim:\t{dist_miles_combined_rust:.2f}")
-    energy_combined = sim.fs_kwh_out_ach.sum()
-    energy_combined_rust = sum(sim_rust.fs_kwh_out_ach)
-    print(f"Fuel Supply achieved in kilowatts-hours: Pure Python FastSim:\t{energy_combined:.2f}\t Rust backend FastSim:\t{energy_combined_rust:.2f}")
+    dist_miles_combined = np.array(sim.dist_mi).sum()
+    print(f"Distance modelled in miles:\t{dist_miles_combined:.2f}")
+    energy_combined = np.array(sim.fs_kwh_out_ach).sum()
+    print(f"Fuel Supply achieved in kilowatts-hours:\t{energy_combined:.2f}")
     fe_mpgge_combined = sim.mpgge
-    fe_mpgge_combined_rust = sim_rust.mpgge
     fe_l__100km_combined = utils.mpg_to_l__100km(fe_mpgge_combined)
-    fe_l__100km_combined_rust = utils.mpg_to_l__100km(fe_mpgge_combined_rust)
-    print(f"Fuel Consumption achieved in L/100km: Pure Python FastSim:\t{fe_l__100km_combined:.2f}\t Rust backend FastSim:\t{fe_l__100km_combined_rust:.2f}")
+    print(f"Fuel Consumption achieved in L/100km:\t{fe_l__100km_combined:.2f}")
 
     i0 = len(wltp_low_cyc_3.time_s)
     i1 = i0 + len(wltp_med_cyc_3b.time_s)-1
@@ -103,7 +90,7 @@ def hybrid_eu_veh_wltp_fe_test():
             cur_energy_consumption_kwh = sum(np.array(sim.fs_kwh_out_ach)[cur_phase_slice])
             cur_fe_mpgge = cur_dist_miles / (cur_energy_consumption_kwh/sim.props.kwh_per_gge)
             cur_fe_liter__100km = utils.mpg_to_l__100km(cur_fe_mpgge)
-            cur_dSOC = sim.soc[cur_phase_slice][-1] - sim.soc[cur_phase_slice][0]
+            cur_dSOC = np.array(sim.soc)[cur_phase_slice][-1] - np.array(sim.soc)[cur_phase_slice][0]
             cur_dE_wh = -cur_dSOC * cur_veh.ess_max_kwh * 1000
             cur_dM_CO2_gram__100km  = 0.0036 * cur_dE_wh * 1/cur_veh.alt_eff * WILLANS_FACTOR_gram_CO2__MJ * 1/cur_dist_km
             cur_dfe_liter__100km = cur_dE_wh/1000 * 1/cur_veh.alt_eff * 1/E10_HEAT_VALUE_kWh__liter * 100/cur_dist_km
@@ -112,33 +99,27 @@ def hybrid_eu_veh_wltp_fe_test():
         return fe_liter__100km_list
     
     fe_low3_l__100km, fe_med3b_l__100km, fe_high3b_l__100km, fe_extrahigh3_l__100km = hybrid_veh_fe_soc_correction(veh_2022_yaris, sim, wltp_3b_phase_slice_list)
-    fe_low3_l__100km_rust, fe_med3b_l__100km_rust, fe_high3b_l__100km_rust, fe_extrahigh3_l__100km_rust = hybrid_veh_fe_soc_correction(veh_2022_yaris_rust, sim_rust, wltp_3b_phase_slice_list)
     
     print("LOW")
     print(f"  Target: {meas_fe_low_liter__100km} L/100km")
     print(f"  Simulation:  {fe_low3_l__100km:.2f} L/100km ({(fe_low3_l__100km - meas_fe_low_liter__100km)/meas_fe_low_liter__100km * 100:+.2f}%)")
-    print(f"  Rust Simulation:  {fe_low3_l__100km_rust:.2f} L/100km ({(fe_low3_l__100km_rust - meas_fe_low_liter__100km)/meas_fe_low_liter__100km * 100:+.2f}%)")
 
     print("MEDIUM")
     print(f"  Target: {meas_fe_med_liter__100km} L/100km")
     print(f"  Simulation:  {fe_med3b_l__100km:.2f} L/100km ({(fe_med3b_l__100km - meas_fe_med_liter__100km)/meas_fe_med_liter__100km * 100:+.2f}%)")
-    print(f"  Rust Simulation:  {fe_med3b_l__100km_rust:.2f} L/100km ({(fe_med3b_l__100km_rust - meas_fe_med_liter__100km)/meas_fe_med_liter__100km * 100:+.2f}%)")
 
     print("HIGH")
     print(f"  Target: {meas_fe_high_liter__100km} L/100km")
     print(f"  Simulation:  {fe_high3b_l__100km:.2f} L/100km ({(fe_high3b_l__100km - meas_fe_high_liter__100km)/meas_fe_high_liter__100km * 100:+.2f}%)")
-    print(f"  Rust Simulation:  {fe_high3b_l__100km_rust:.2f} L/100km ({(fe_high3b_l__100km_rust - meas_fe_high_liter__100km)/meas_fe_high_liter__100km * 100:+.2f}%)")
 
 
     print("EXTRA-HIGH")
     print(f"  Target: {meas_fe_extrahigh_liter__100km} L/100km")
     print(f"  Simulation:  {fe_extrahigh3_l__100km:.6f} L/100km ({(fe_extrahigh3_l__100km - meas_fe_extrahigh_liter__100km)/meas_fe_extrahigh_liter__100km * 100:+.6f}%)")
-    print(f"  Rust Simulation:  {fe_extrahigh3_l__100km_rust:.6f} L/100km ({(fe_extrahigh3_l__100km_rust - meas_fe_extrahigh_liter__100km)/meas_fe_extrahigh_liter__100km * 100:+.6f}%)")
 
     print("COMBINED")
     print(f"  Target: {meas_fe_combined_liter__100km} L/100km")
     print(f"  Simulation: {fe_l__100km_combined:.6f} L/100km ({(fe_l__100km_combined - meas_fe_combined_liter__100km)/meas_fe_combined_liter__100km * 100:+.6f}%)")
-    print(f"  Rust Simulation: {fe_l__100km_combined_rust:.2f} L/100km ({(fe_l__100km_combined_rust - meas_fe_combined_liter__100km)/meas_fe_combined_liter__100km * 100:+.2f}%)")
 
 if __name__ == '__main__':
     hybrid_eu_veh_wltp_fe_test()

--- a/python/fastsim/demos/stop_start_demo.py
+++ b/python/fastsim/demos/stop_start_demo.py
@@ -53,9 +53,9 @@ print(f"Elapsed time: {time.time() - t0:.3e} s")
 
 # %%
 t0 = time.time()
-sim_drive0 = simdrive.SimDrive(cyc, veh0)
+sim_drive0 = simdrive.RustSimDrive(cyc.to_rust(), veh0.to_rust())
 sim_drive0.sim_drive()
-sim_drive1 = simdrive.SimDrive(cyc, veh1)
+sim_drive1 = simdrive.RustSimDrive(cyc.to_rust(), veh1.to_rust())
 sim_drive1.sim_drive()
 print(f"Elapsed time: {time.time() - t0:.3e} s")
 

--- a/python/fastsim/demos/time_dilation_demo.py
+++ b/python/fastsim/demos/time_dilation_demo.py
@@ -40,14 +40,14 @@ print('Time to load vehicle: {:.3f} s'.format(time.time() - t0))
 
 t0 = time.time()
 
-sd_fixed = simdrive.SimDrive(cyc, veh)
+sd_fixed = simdrive.RustSimDrive(cyc.to_rust(), veh.to_rust())
 sim_params = sd_fixed.sim_params
 sim_params.missed_trace_correction=True
 # sim_params.min_time_dilation = 1
 sim_params.max_time_dilation = 0.1
 # sim_params.time_dilation_tol = 1e-1
 
-sd_base = simdrive.SimDrive(cyc, veh)
+sd_base = simdrive.RustSimDrive(cyc.to_rust(), veh.to_rust())
 
 sd_fixed.sim_drive() 
 sd_base.sim_drive()

--- a/python/fastsim/demos/time_dilation_demo.py
+++ b/python/fastsim/demos/time_dilation_demo.py
@@ -57,15 +57,15 @@ sd_base.sim_drive()
 t_delta = time.time() - t0
 
 print('Time to run sim_drive: {:.3f} s'.format(t_delta))
-print('Mean number of trace miss iterations: {:.3f}'.format(sd_fixed.trace_miss_iters.mean()))
+print('Mean number of trace miss iterations: {:.3f}'.format(np.array(sd_fixed.trace_miss_iters).mean()))
 print('Distance percent error w.r.t. base cycle: {:.3%}'.format(
-    (sd_fixed.dist_m.sum() - cyc.dist_m.sum()) / cyc.dist_m.sum()))
+    (np.array(sd_fixed.dist_m).sum() - cyc.dist_m.sum()) / cyc.dist_m.sum()))
 
 # elevation delta based on dilated cycle secs
-delta_elev_dilated = (sd_fixed.cyc.grade * sd_fixed.cyc.dt_s * sd_fixed.cyc.mps).sum()
+delta_elev_dilated = (np.array(sd_fixed.cyc.grade) * np.array(sd_fixed.cyc.dt_s) * np.array(sd_fixed.cyc.mps)).sum()
 # elevation delta based on dilated cycle secs
-delta_elev_achieved = (sd_fixed.cyc.grade *
-                      sd_fixed.cyc.dt_s * sd_fixed.mps_ach).sum()
+delta_elev_achieved = (np.array(sd_fixed.cyc.grade) *
+                      np.array(sd_fixed.cyc.dt_s) * np.array(sd_fixed.mps_ach)).sum()
 
 # PLOTS
 
@@ -97,10 +97,10 @@ if SHOW_PLOTS:
 
 plt.figure()
 plt.plot(cyc.time_s, (cyc.mps * cyc.dt_s).cumsum() / 1e3, label='trace')
-plt.plot(sd_fixed.cyc.time_s, (sd_fixed.mps_ach *
-                                 sd_fixed.cyc.dt_s).cumsum() / 1e3, label='dilated', linestyle='--')
-plt.plot(sd_base.cyc.time_s, (sd_base.mps_ach *
-                                 sd_base.cyc.dt_s).cumsum() / 1e3, label='base', linestyle='-.')
+plt.plot(sd_fixed.cyc.time_s, (np.array(sd_fixed.mps_ach) *
+                                 np.array(sd_fixed.cyc.dt_s)).cumsum() / 1e3, label='dilated', linestyle='--')
+plt.plot(sd_base.cyc.time_s, (np.array(sd_base.mps_ach) *
+                                 np.array(sd_base.cyc.dt_s)).cumsum() / 1e3, label='base', linestyle='-.')
 # plt.grid()
 plt.legend(loc='upper left')
 plt.xlabel('Time [s]')
@@ -111,9 +111,9 @@ if SHOW_PLOTS:
 
 plt.figure()
 plt.plot((cyc.mps * cyc.dt_s).cumsum() / 1e3, label='trace')
-plt.plot((sd_fixed.mps_ach * sd_fixed.cyc.dt_s).cumsum() / 1e3,
+plt.plot((np.array(sd_fixed.mps_ach) * np.array(sd_fixed.cyc.dt_s)).cumsum() / 1e3,
          label='dilated', linestyle='--')
-plt.plot((sd_base.mps_ach * sd_base.cyc.dt_s).cumsum() / 1e3,
+plt.plot((np.array(sd_base.mps_ach) * np.array(sd_base.cyc.dt_s)).cumsum() / 1e3,
          label='base', linestyle='-.')
 # plt.grid()
 plt.legend(loc='upper left')
@@ -128,7 +128,7 @@ plt.plot(sd_fixed.cyc.time_s,
     (np.interp(
     sd_fixed.cyc.time_s, 
     cyc.time_s, 
-    cyc.dist_m.cumsum()) - sd_fixed.dist_m.cumsum())
+    cyc.dist_m.cumsum()) - np.array(sd_fixed.dist_m).cumsum())
          / 1e3)
 # plt.grid()
 plt.xlabel('Time [s]')
@@ -140,7 +140,7 @@ if SHOW_PLOTS:
 
 plt.figure()
 plt.plot((cyc.dist_m.cumsum() -
-         sd_fixed.dist_m.cumsum()))
+         np.array(sd_fixed.dist_m).cumsum()))
 # plt.grid()
 plt.xlabel('Index')
 plt.ylabel('Distance (trace - achieved) [m]')
@@ -154,9 +154,9 @@ if SHOW_PLOTS:
 plt.figure()
 plt.plot(cyc.time_s, (cyc.grade * cyc.mps * cyc.dt_s).cumsum(), label='trace')
 plt.plot(sd_fixed.cyc.time_s, (cyc.grade * cyc.dt_s *
-                                 sd_fixed.mps_ach).cumsum(), label='undilated', linestyle='--')
-plt.plot(sd_fixed.cyc.time_s, (sd_fixed.cyc.grade * sd_fixed.cyc.dt_s *
-                                 sd_fixed.mps_ach).cumsum(), label='dilated', linestyle='-.')
+                                 np.array(sd_fixed.mps_ach)).cumsum(), label='undilated', linestyle='--')
+plt.plot(sd_fixed.cyc.time_s, (np.array(sd_fixed.cyc.grade) * np.array(sd_fixed.cyc.dt_s) *
+                                 np.array(sd_fixed.mps_ach)).cumsum(), label='dilated', linestyle='-.')
 # plt.grid()
 plt.legend(loc='upper left')
 plt.xlabel('Time [s]')
@@ -169,9 +169,9 @@ if SHOW_PLOTS:
 plt.figure()
 plt.plot((cyc.grade * cyc.mps *
                        cyc.dt_s).cumsum(), label='trace')
-plt.plot((cyc.grade * cyc.dt_s * sd_fixed.mps_ach).cumsum(), label='undilated', linestyle='--')
-plt.plot((sd_fixed.cyc.grade * sd_fixed.cyc.dt_s *
-                                 sd_fixed.mps_ach).cumsum(), label='dilated', linestyle='-.')
+plt.plot((cyc.grade * cyc.dt_s * np.array(sd_fixed.mps_ach)).cumsum(), label='undilated', linestyle='--')
+plt.plot((np.array(sd_fixed.cyc.grade) * np.array(sd_fixed.cyc.dt_s) *
+                                 np.array(sd_fixed.mps_ach)).cumsum(), label='dilated', linestyle='-.')
 # plt.grid()
 plt.legend(loc='upper left')
 plt.xlabel('Index')

--- a/python/fastsim/demos/time_dilation_demo.py
+++ b/python/fastsim/demos/time_dilation_demo.py
@@ -42,10 +42,12 @@ t0 = time.time()
 
 sd_fixed = simdrive.RustSimDrive(cyc.to_rust(), veh.to_rust())
 sim_params = sd_fixed.sim_params
+sim_params.reset_orphaned()
 sim_params.missed_trace_correction=True
 # sim_params.min_time_dilation = 1
 sim_params.max_time_dilation = 0.1
 # sim_params.time_dilation_tol = 1e-1
+sd_fixed.sim_params = sim_params
 
 sd_base = simdrive.RustSimDrive(cyc.to_rust(), veh.to_rust())
 

--- a/python/fastsim/demos/timing_demo.py
+++ b/python/fastsim/demos/timing_demo.py
@@ -56,7 +56,7 @@ print(f'Time to load cycle with `fastsimrust.RustCycle.from_file`: {t1 - t0:.2e}
 
 veh_csv_path = fsim.package_root() / "resources/vehdb/2012_Ford_Fusion.csv"
 t0 = time.perf_counter()
-veh_python = fsim.vehicle.Vehicle.from_file(str(veh_csv_path), to_rust=True)
+veh_python = fsim.vehicle.Vehicle.from_file(str(veh_csv_path), to_rust=True).to_rust()
 print(
     'Time to load vehicle with\n' + 
     f'`vehicle.Vehicle.from_file(veh_csv_path)`: {time.perf_counter() - t0:.2e} s'

--- a/python/fastsim/tests/test_eco_cruise.py
+++ b/python/fastsim/tests/test_eco_cruise.py
@@ -80,7 +80,6 @@ class TestEcoCruise(unittest.TestCase):
 
     def test_that_eco_cruise_works_with_blend_factor(self):
         for use_rust in [False, True]:
-            # should this instead be sd, _, _ = self.make_simdrive(use_rust=use_rust)
             sd, _, _ = self.make_simdrive()
             sd.activate_eco_cruise(by_microtrip=True, blend_factor=1.0)
             sd.sim_drive()

--- a/python/fastsim/tests/test_eco_cruise.py
+++ b/python/fastsim/tests/test_eco_cruise.py
@@ -80,6 +80,7 @@ class TestEcoCruise(unittest.TestCase):
 
     def test_that_eco_cruise_works_with_blend_factor(self):
         for use_rust in [False, True]:
+            # should this instead be sd, _, _ = self.make_simdrive(use_rust=use_rust)
             sd, _, _ = self.make_simdrive()
             sd.activate_eco_cruise(by_microtrip=True, blend_factor=1.0)
             sd.sim_drive()


### PR DESCRIPTION
This commit updates the `fastsim-2` demo files to run Rust instead of Python where Python was formerly used for `sim_drive` functions, and only use Rust where Rust and Python were both used (except in the one case where Rust and Python speeds are being intentionally and directly compared (code lines 50-116 of [demo.py](https://github.com/NREL/fastsim/blob/have-demos-run-rust/python/fastsim/demos/demo.py)).