### PR TITLE
Add copy_demo_files()

### DIFF
--- a/python/fastsim/__init__.py
+++ b/python/fastsim/__init__.py
@@ -9,6 +9,8 @@ def package_root() -> Path:
     """Returns the package root directory."""
     return Path(__file__).parent
 
+from pkg_resources import get_distribution
+__version__ = get_distribution("fastsim").version
 
 def set_param_from_path(
     model: Any,

--- a/python/fastsim/tests/test_utils.py
+++ b/python/fastsim/tests/test_utils.py
@@ -1,0 +1,21 @@
+import tempfile
+import unittest
+from pathlib import Path
+import fastsim as fsim
+import fastsim.utils.utilities as utils
+
+class TestUtils(unittest.TestCase):
+
+    def test_copy_demo_files(self):
+        v = f"v{fsim.__version__}"
+        prepend_str = f"# %% Copied from FASTSim version '{v}'. Guaranteed compatibility with this version only.\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tf_path = Path(tmpdir)
+            utils.copy_demo_files(tf_path)
+            with open(next(tf_path.glob("*demo*.py")), 'r') as file:
+                lines = file.readlines()
+                assert prepend_str in lines[0]
+                assert len(lines) > 3
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/fastsim/tests/test_utils.py
+++ b/python/fastsim/tests/test_utils.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 import fastsim as fsim
-import fastsim.utils.utilities as utils
+from fastsim import utils
 
 class TestUtils(unittest.TestCase):
 

--- a/python/fastsim/utils/__init__.py
+++ b/python/fastsim/utils/__init__.py
@@ -1,0 +1,1 @@
+from .utilities import *

--- a/python/fastsim/utils/utilities.py
+++ b/python/fastsim/utils/utilities.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import shutil
 import fastsim as fsim
-import fastsim.__init__ as init
 
 def copy_demo_files(path_for_copies: Path=Path("demos")):
     """
@@ -14,7 +13,7 @@ def copy_demo_files(path_for_copies: Path=Path("demos")):
     make sure any files with changes you'd like to keep are renamed.
     """
     v = f"v{fsim.__version__}"
-    current_demo_path = init.package_root() / "demos"
+    current_demo_path = fsim.package_root() / "demos"
     assert Path(path_for_copies).resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
     demo_files = list(current_demo_path.glob('*demo*.py'))
     test_demo_files = list(current_demo_path.glob('*test*.py'))

--- a/python/fastsim/utils/utilities.py
+++ b/python/fastsim/utils/utilities.py
@@ -1,0 +1,46 @@
+import os
+from pathlib import Path
+import shutil
+import fastsim as fsim
+
+
+def copy_demo_files(path_for_copies: Path=Path("demos")):
+    """
+    Copies demo files from demos folder into specified local directory
+    # Arguments
+    - `path_for_copies`: path to copy files into (relative or absolute in)
+    # Warning
+    Running this function will overwrite existing files with the same name in the specified directory, so 
+    make sure any files with changes you'd like to keep are renamed.
+    """
+    v = f"v{fsim.__version__}"
+    current_demo_path = fsim.package_root() / "demos"
+    assert path_for_copies.resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
+    demo_files = list(current_demo_path.glob('*demo*.py'))
+    test_demo_files = list(current_demo_path.glob('*test*.py'))
+    for file in test_demo_files:
+        demo_files.remove(file)
+    for file in demo_files:
+        if os.path.exists(path_for_copies):
+            dest_file = path_for_copies / file.name
+            shutil.copy(file, path_for_copies)
+            with open(dest_file, "r+") as file:
+                file_content = file.readlines()
+                prepend_str = f"# %% Copied from FASTSim version '{v}'. Guaranteed compatibility with this version only.\n"
+                prepend = [prepend_str]
+                file_content = prepend + file_content
+                file.seek(0)
+                file.writelines(file_content)
+            print(f"Saved {dest_file.name} to {dest_file}")
+        else:
+            os.makedirs(path_for_copies)
+            dest_file = path_for_copies / file.name
+            shutil.copy(file, path_for_copies)
+            with open(dest_file, "r+") as file:
+                file_content = file.readlines()
+                prepend_str = f"# %% Copied from FASTSim version '{v}'. Guaranteed compatibility with this version only.\n"
+                prepend = [prepend_str]
+                file_content = prepend + file_content
+                file.seek(0)
+                file.writelines(file_content)
+            print(f"Saved {dest_file.name} to {dest_file}")

--- a/python/fastsim/utils/utilities.py
+++ b/python/fastsim/utils/utilities.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import shutil
 import fastsim as fsim
-
+import fastsim.__init__ as init
 
 def copy_demo_files(path_for_copies: Path=Path("demos")):
     """
@@ -14,15 +14,15 @@ def copy_demo_files(path_for_copies: Path=Path("demos")):
     make sure any files with changes you'd like to keep are renamed.
     """
     v = f"v{fsim.__version__}"
-    current_demo_path = fsim.package_root() / "demos"
-    assert path_for_copies.resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
+    current_demo_path = init.package_root() / "demos"
+    assert Path(path_for_copies).resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
     demo_files = list(current_demo_path.glob('*demo*.py'))
     test_demo_files = list(current_demo_path.glob('*test*.py'))
     for file in test_demo_files:
         demo_files.remove(file)
     for file in demo_files:
         if os.path.exists(path_for_copies):
-            dest_file = path_for_copies / file.name
+            dest_file = Path(path_for_copies) / file.name
             shutil.copy(file, path_for_copies)
             with open(dest_file, "r+") as file:
                 file_content = file.readlines()

--- a/python/fastsim/utils/utilities.py
+++ b/python/fastsim/utils/utilities.py
@@ -33,7 +33,7 @@ def copy_demo_files(path_for_copies: Path=Path("demos")):
             print(f"Saved {dest_file.name} to {dest_file}")
         else:
             os.makedirs(path_for_copies)
-            dest_file = path_for_copies / file.name
+            dest_file = Path(path_for_copies) / file.name
             shutil.copy(file, path_for_copies)
             with open(dest_file, "r+") as file:
                 file_content = file.readlines()


### PR DESCRIPTION
I added copy_demo_files() into `fastsim-3`, as well as adding a `test_utils.py` file with a `test_copy_demo_files()` function that runs during `sh build_and_test.sh`. I tested the function manually as well, and it correctly copies the current `fastsim-3` demos into either a `demos` folder or a specified path.