### PR TITLE
updating copy_demo_files() to accept either a Path or a string

### DIFF
--- a/python/fastsim/utils/utilities.py
+++ b/python/fastsim/utils/utilities.py
@@ -425,14 +425,14 @@ def copy_demo_files(path_for_copies: Path=Path("demos")):
     """
     v = f"v{fsim.__version__}"
     current_demo_path = fsim.package_root() / "demos"
-    assert path_for_copies.resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
+    assert Path(path_for_copies).resolve() != Path(current_demo_path), "Can't copy demos inside site-packages"
     demo_files = list(current_demo_path.glob('*demo*.py'))
     test_demo_files = list(current_demo_path.glob('*test*.py'))
     for file in test_demo_files:
         demo_files.remove(file)
     for file in demo_files:
         if os.path.exists(path_for_copies):
-            dest_file = path_for_copies / file.name
+            dest_file = Path(path_for_copies) / file.name
             shutil.copy(file, path_for_copies)
             with open(dest_file, "r+") as file:
                 file_content = file.readlines()
@@ -444,7 +444,7 @@ def copy_demo_files(path_for_copies: Path=Path("demos")):
             print(f"Saved {dest_file.name} to {dest_file}")
         else:
             os.makedirs(path_for_copies)
-            dest_file = path_for_copies / file.name
+            dest_file = Path(path_for_copies) / file.name
             shutil.copy(file, path_for_copies)
             with open(dest_file, "r+") as file:
                 file_content = file.readlines()


### PR DESCRIPTION
Realized when created a `copy_demo_files()` function in `fastsim-3` that the current version of the function only accepted a Path, and threw an error if a path that was input as a string was given as the argument. This is a small update to fix that and ensure that a path given as a string also works.