### PR TITLE
Port latest SerdeAPI changes to FASTSim 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,8 @@ dependencies = [
  "serde_yaml 0.8.26",
  "toml",
  "uom",
+ "ureq",
+ "url",
 ]
 
 [[package]]

--- a/benchmarks/f2.py
+++ b/benchmarks/f2.py
@@ -12,7 +12,7 @@ def build_and_run_sim_drive():
     veh = fsr.RustVehicle.from_file(
         str(fsim.package_root() / "resources/vehdb/2012_Ford_Fusion.yaml")
     )
-    cyc = fsr.RustCycle.from_resource("cycles/udds.csv")
+    cyc = fsr.RustCycle.from_resource("udds.csv")
     sd = fsr.RustSimDrive(cyc, veh)
     sd.sim_drive()
 
@@ -28,6 +28,6 @@ if __name__ == "__main__":
     # 12  164.234 MiB    0.797 MiB           2       veh = fsr.RustVehicle.from_file(
     # 13  163.438 MiB    0.000 MiB           1           str(fsim.package_root() / "resources/vehdb/2012_Ford_Fusion.yaml")
     # 14                                             )
-    # 15  164.375 MiB    0.141 MiB           1       cyc = fsr.RustCycle.from_resource("cycles/udds.csv")
+    # 15  164.375 MiB    0.141 MiB           1       cyc = fsr.RustCycle.from_resource("udds.csv")
     # 16  165.453 MiB    1.078 MiB           1       sd = fsr.RustSimDrive(cyc, veh)
     # 17  165.656 MiB    0.203 MiB           1       sd.sim_drive()

--- a/benchmarks/f3-save-int-1.py
+++ b/benchmarks/f3-save-int-1.py
@@ -9,7 +9,7 @@ def build_and_run_sim_drive():
         str(fsim.package_root() / "../../tests/assets/2012_Ford_Fusion.yaml")
     )
     veh.save_interval = 1
-    cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+    cyc = fsim.Cycle.from_resource("udds.csv")
     sd = fsim.SimDrive(veh, cyc)
     sd.walk()
 
@@ -27,6 +27,6 @@ if __name__ == "__main__":
      # 9   61.562 MiB    0.000 MiB           1           str(fsim.package_root() / "../../tests/assets/2012_Ford_Fusion.yaml")
     # 10                                             )
     # 11   62.125 MiB    0.000 MiB           1       veh.save_interval = 1
-    # 12   62.312 MiB    0.188 MiB           1       cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+    # 12   62.312 MiB    0.188 MiB           1       cyc = fsim.Cycle.from_resource("udds.csv")
     # 13   62.406 MiB    0.094 MiB           1       sd = fsim.SimDrive(veh, cyc)
     # 14   62.953 MiB    0.547 MiB           1       sd.walk()

--- a/benchmarks/f3-save-int-none.py
+++ b/benchmarks/f3-save-int-none.py
@@ -9,7 +9,7 @@ def build_and_run_sim_drive():
         str(fsim.package_root() / "../../tests/assets/2012_Ford_Fusion.yaml")
     )
     veh.save_interval = None
-    cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+    cyc = fsim.Cycle.from_resource("udds.csv")
     sd = fsim.SimDrive(veh, cyc)
     sd.walk()
 
@@ -27,6 +27,6 @@ if __name__ == "__main__":
 #      9   61.203 MiB    0.000 MiB           1           str(fsim.package_root() / "../../tests/assets/2012_Ford_Fusion.yaml")
 #     10                                             )
 #     11   61.766 MiB    0.000 MiB           1       veh.save_interval = None
-#     12   61.938 MiB    0.172 MiB           1       cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+#     12   61.938 MiB    0.172 MiB           1       cyc = fsim.Cycle.from_resource("udds.csv")
 #     13   62.031 MiB    0.094 MiB           1       sd = fsim.SimDrive(veh, cyc)
 #     14   62.031 MiB    0.000 MiB           1       sd.walk()

--- a/fastsim-core/Cargo.toml
+++ b/fastsim-core/Cargo.toml
@@ -39,10 +39,9 @@ url = { version = "2.5.0", optional = true }
 
 [features]
 default = ["resources", "serde-default", "web"]
-# cache = []
 pyo3 = ["dep:pyo3", "fastsim-2/pyo3"]
 resources = ["dep:include_dir"]
-web = ["dep:ureq", "dep:url"]         # internet-querying dependencies
+web = ["dep:ureq", "dep:url"]                   # internet-querying dependencies
 # serde formats
 serde-default = ["csv", "json", "toml", "yaml"]
 bincode = ["dep:bincode"]

--- a/fastsim-core/Cargo.toml
+++ b/fastsim-core/Cargo.toml
@@ -42,7 +42,7 @@ default = ["resources", "serde-default", "web"]
 # cache = []
 pyo3 = ["dep:pyo3", "fastsim-2/pyo3"]
 resources = ["dep:include_dir"]
-web = ["dep:ureq", "dep:url"]
+web = ["dep:ureq", "dep:url"]         # internet-querying dependencies
 # serde formats
 serde-default = ["csv", "json", "toml", "yaml"]
 bincode = ["dep:bincode"]

--- a/fastsim-core/Cargo.toml
+++ b/fastsim-core/Cargo.toml
@@ -6,36 +6,47 @@ edition = { workspace = true }
 [dependencies]
 fastsim-proc-macros = { path = "fastsim-proc-macros", version = "3.0.0" }
 fastsim-2 = { workspace = true }
-csv = "1.1.6"
+csv = { version = "1.1.6", optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
-serde_yaml = "0.8.23"
-serde_json = "1.0"
+serde_yaml = { version = "0.8.23", optional = true }
+serde_json = { version = "1.0", optional = true }
 uom = { workspace = true }
 paste = "1.0.7"
 easy-ext = "1.0.0"
 rayon = "1.5.3"
-bincode = "1.3.3"
+bincode = { version = "1.3.3", optional = true }
 log = "0.4.17"
 anyhow = { workspace = true }
 readonly = "0.2.3"
 duplicate = "0.4.1"
 nohash-hasher = "0.2.0"
 eng_fmt = "0.1.2"
-
-# optional
 pyo3 = { workspace = true, features = [
     "extension-module",
     "anyhow",
 ], optional = true }
 serde-this-or-that = "0.4.2"
 project-root = "0.2.2"
-include_dir = "0.7.3"
+include_dir = { version = "0.7.3", optional = true }
 itertools = "0.12.0"
 lazy_static = "1.4.0"
 regex = "1.10.3"
 ndarray = "0.15.6"
-toml = "0.8.12"
+toml = { version = "0.8.12", optional = true }
 derive_more = "0.99.17"
+ureq = { version = "2.9.1", optional = true }
+url = { version = "2.5.0", optional = true }
 
 [features]
+default = ["resources", "serde-default", "web"]
+# cache = []
 pyo3 = ["dep:pyo3", "fastsim-2/pyo3"]
+resources = ["dep:include_dir"]
+web = ["dep:ureq", "dep:url"]
+# serde formats
+serde-default = ["csv", "json", "toml", "yaml"]
+bincode = ["dep:bincode"]
+csv = ["dep:csv"]
+json = ["dep:serde_json"]
+toml = ["dep:toml"]
+yaml = ["dep:serde_yaml"]

--- a/fastsim-core/fastsim-proc-macros/src/pyo3_api.rs
+++ b/fastsim-core/fastsim-proc-macros/src/pyo3_api.rs
@@ -159,60 +159,160 @@ pub(crate) fn pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         pub fn __copy__(&self) -> Self {self.clone()}
         pub fn __deepcopy__(&self, _memo: &PyDict) -> Self {self.clone()}
 
+        /// Read (deserialize) an object from a resource file packaged with the `fastsim-core` crate
+        ///
+        /// # Arguments:
+        ///
+        /// * `filepath`: `str | pathlib.Path` - Filepath, relative to the top of the `resources` folder (excluding any relevant prefix), from which to read the object
+        ///
+        #[cfg(feature = "resources")]
         #[staticmethod]
         #[pyo3(name = "from_resource")]
-        pub fn from_resource_py(filepath: &PyAny) -> anyhow::Result<Self> {
-            Self::from_resource(PathBuf::extract(filepath)?)
+        pub fn from_resource_py(filepath: &PyAny, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_resource(PathBuf::extract(filepath)?, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
+        /// Read (deserialize) an object from a resource file packaged with the `fastsim-core` crate
+        ///
+        /// # Arguments:
+        ///
+        /// * `url`: `str` - URL from which to read the object
+        ///
+        #[cfg(feature = "url")]
+        #[staticmethod]
+        #[pyo3(name = "from_url")]
+        pub fn from_url_py(url: &str, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_url(url, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Write (serialize) an object to a file.
+        /// Supported file extensions are listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`).
+        /// Creates a new file if it does not already exist, otherwise truncates the existing file.
+        ///
+        /// # Arguments
+        ///
+        /// * `filepath`: `str | pathlib.Path` - The filepath at which to write the object
+        ///
+        #[pyo3(name = "to_file")]
+        pub fn to_file_py(&self, filepath: &PyAny) -> PyResult<()> {
+           self.to_file(PathBuf::extract(filepath)?).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Read (deserialize) an object from a file.
+        /// Supported file extensions are listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`).
+        ///
+        /// # Arguments:
+        ///
+        /// * `filepath`: `str | pathlib.Path` - The filepath from which to read the object
+        ///
+        #[staticmethod]
+        #[pyo3(name = "from_file")]
+        pub fn from_file_py(filepath: &PyAny, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_file(PathBuf::extract(filepath)?, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Write (serialize) an object into a string
+        ///
+        /// # Arguments:
+        ///
+        /// * `format`: `str` - The target format, any of those listed in [`ACCEPTED_STR_FORMATS`](`SerdeAPI::ACCEPTED_STR_FORMATS`)
+        ///
         #[pyo3(name = "to_str")]
-        pub fn to_str_py(&self, format: &str) -> anyhow::Result<String> {
-            self.to_str(format)
+        pub fn to_str_py(&self, format: &str) -> PyResult<String> {
+            self.to_str(format).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
+        /// Read (deserialize) an object from a string
+        ///
+        /// # Arguments:
+        ///
+        /// * `contents`: `str` - The string containing the object data
+        /// * `format`: `str` - The source format, any of those listed in [`ACCEPTED_STR_FORMATS`](`SerdeAPI::ACCEPTED_STR_FORMATS`)
+        ///
         #[staticmethod]
         #[pyo3(name = "from_str")]
-        pub fn from_str_py(contents: &str, format: &str) -> anyhow::Result<Self> {
-            Self::from_str(contents, format)
+        pub fn from_str_py(contents: &str, format: &str, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_str(contents, format, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
-        /// JSON serialization method.
-        #[pyo3(name = "to_json")]
-        pub fn to_json_py(&self) -> anyhow::Result<String> {
-            self.to_json()
-        }
-
-        #[staticmethod]
-        /// JSON deserialization method.
-        #[pyo3(name = "from_json")]
-        pub fn from_json_py(json_str: &str) -> anyhow::Result<Self> {
-            Self::from_json(json_str)
-        }
-
-        /// YAML serialization method.
-        #[pyo3(name = "to_yaml")]
-        pub fn to_yaml_py(&self) -> anyhow::Result<String> {
-            self.to_yaml()
-        }
-
-        #[staticmethod]
-        /// YAML deserialization method.
-        #[pyo3(name = "from_yaml")]
-        pub fn from_yaml_py(yaml_str: &str) -> anyhow::Result<Self> {
-            Self::from_yaml(yaml_str)
-        }
-
-        /// bincode serialization method.
+        /// Write (serialize) an object to bincode-encoded `bytes`
+        #[cfg(feature = "bincode")]
         #[pyo3(name = "to_bincode")]
-        pub fn to_bincode_py<'py>(&self, py: Python<'py>) -> anyhow::Result<&'py PyBytes> {
-            Ok(PyBytes::new(py, &self.to_bincode()?))
+        pub fn to_bincode_py<'py>(&self, py: Python<'py>) -> PyResult<&'py PyBytes> {
+            PyResult::Ok(PyBytes::new(py, &self.to_bincode()?)).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
 
+        /// Read (deserialize) an object from bincode-encoded `bytes`
+        ///
+        /// # Arguments
+        ///
+        /// * `encoded`: `bytes` - Encoded bytes to deserialize from
+        ///
+        #[cfg(feature = "bincode")]
         #[staticmethod]
-        /// bincode deserialization method.
         #[pyo3(name = "from_bincode")]
-        pub fn from_bincode_py(encoded: &PyBytes) -> anyhow::Result<Self> {
-            Self::from_bincode(encoded.as_bytes())
+        pub fn from_bincode_py(encoded: &PyBytes, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_bincode(encoded.as_bytes(), skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+        
+        /// Write (serialize) an object to a JSON string
+        #[cfg(feature = "json")]
+        #[pyo3(name = "to_json")]
+        pub fn to_json_py(&self) -> PyResult<String> {
+            self.to_json().map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Read (deserialize) an object to a JSON string
+        ///
+        /// # Arguments
+        ///
+        /// * `json_str`: `str` - JSON-formatted string to deserialize from
+        ///
+        #[cfg(feature = "json")]
+        #[staticmethod]
+        #[pyo3(name = "from_json")]
+        pub fn from_json_py(json_str: &str, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_json(json_str, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Write (serialize) an object to a TOML string
+        #[cfg(feature = "toml")]
+        #[pyo3(name = "to_toml")]
+        pub fn to_toml_py(&self) -> PyResult<String> {
+            self.to_toml().map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Read (deserialize) an object to a TOML string
+        ///
+        /// # Arguments
+        ///
+        /// * `toml_str`: `str` - TOML-formatted string to deserialize from
+        ///
+        #[cfg(feature = "toml")]
+        #[staticmethod]
+        #[pyo3(name = "from_toml")]
+        pub fn from_toml_py(toml_str: &str, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_toml(toml_str, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+        
+        /// Write (serialize) an object to a YAML string
+        #[cfg(feature = "yaml")]
+        #[pyo3(name = "to_yaml")]
+        pub fn to_yaml_py(&self) -> PyResult<String> {
+            self.to_yaml().map_err(|e| PyIOError::new_err(format!("{:?}", e)))
+        }
+
+        /// Read (deserialize) an object from a YAML string
+        ///
+        /// # Arguments
+        ///
+        /// * `yaml_str`: `str` - YAML-formatted string to deserialize from
+        ///
+        #[cfg(feature = "yaml")]
+        #[staticmethod]
+        #[pyo3(name = "from_yaml")]
+        pub fn from_yaml_py(yaml_str: &str, skip_init: Option<bool>) -> PyResult<Self> {
+            Self::from_yaml(yaml_str, skip_init.unwrap_or_default()).map_err(|e| PyIOError::new_err(format!("{:?}", e)))
         }
     });
 
@@ -222,19 +322,6 @@ pub(crate) fn pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         /// Implement methods exposed and used in Python via PyO3
         impl #ident {
             #py_impl_block
-
-            #[classmethod]
-            #[pyo3(name = "from_file")]
-            /// Exposes `from_file` to Python.
-            fn from_file_py(_cls: &PyType, filename: String) -> PyResult<Self> {
-                Ok(Self::from_file(&filename)?)
-            }
-
-            #[pyo3(name = "to_file")]
-            /// Exposes `to_file` to Python.
-            fn to_file_py(&self, filename: &str) -> PyResult<()> {
-                Ok(self.to_file(filename)?)
-            }
         }
     };
     let mut final_output = TokenStream2::default();

--- a/fastsim-core/fastsim-proc-macros/src/pyo3_api.rs
+++ b/fastsim-core/fastsim-proc-macros/src/pyo3_api.rs
@@ -178,7 +178,7 @@ pub(crate) fn pyo3_api(attr: TokenStream, item: TokenStream) -> TokenStream {
         ///
         /// * `url`: `str` - URL from which to read the object
         ///
-        #[cfg(feature = "url")]
+        #[cfg(feature = "web")]
         #[staticmethod]
         #[pyo3(name = "from_url")]
         pub fn from_url_py(url: &str, skip_init: Option<bool>) -> PyResult<Self> {

--- a/fastsim-core/src/drive_cycle.rs
+++ b/fastsim-core/src/drive_cycle.rs
@@ -115,6 +115,7 @@ impl SerdeAPI for Cycle {
         #[cfg(feature = "yaml")]
         "yaml",
     ];
+    #[cfg(feature = "resources")]
     const RESOURCE_PREFIX: &'static str = "cycles";
     #[cfg(feature = "cache")]
     const CACHE_FOLDER: &'static str = "cycles";
@@ -187,7 +188,7 @@ impl SerdeAPI for Cycle {
             }
             #[cfg(feature = "json")]
             "json" => serde_json::from_reader(rdr)?,
-            #[cfg(feature = "tonl")]
+            #[cfg(feature = "toml")]
             "toml" => {
                 let mut buf = String::new();
                 rdr.read_to_string(&mut buf)?;

--- a/fastsim-core/src/drive_cycle.rs
+++ b/fastsim-core/src/drive_cycle.rs
@@ -117,8 +117,6 @@ impl SerdeAPI for Cycle {
     ];
     #[cfg(feature = "resources")]
     const RESOURCE_PREFIX: &'static str = "cycles";
-    #[cfg(feature = "cache")]
-    const CACHE_FOLDER: &'static str = "cycles";
 
     /// Write (serialize) an object into anything that implements [`std::io::Write`]
     ///

--- a/fastsim-core/src/imports.rs
+++ b/fastsim-core/src/imports.rs
@@ -19,7 +19,6 @@ pub(crate) use eng_fmt::FormatEng;
 pub(crate) use fastsim_proc_macros::{pyo3_api, HistoryMethods, HistoryVec, SetCumulative};
 
 pub(crate) use anyhow::{anyhow, bail, ensure, Context};
-pub(crate) use bincode::{deserialize, serialize};
 pub(crate) use duplicate::duplicate_item;
 pub(crate) use easy_ext::ext;
 pub(crate) use ndarray::prelude::*;

--- a/fastsim-core/src/lib.rs
+++ b/fastsim-core/src/lib.rs
@@ -8,6 +8,31 @@
 //! # Features:
 //! - pyo3: enable this feature to expose FASTSim structs, methods, and functions to Python
 
+/// List enabled features
+#[cfg_attr(feature = "pyo3", imports::pyfunction)]
+pub fn enabled_features() -> Vec<String> {
+    vec![
+        #[cfg(feature = "default")]
+        "default".into(),
+        #[cfg(feature = "resources")]
+        "resources".into(),
+        #[cfg(feature = "web")]
+        "web".into(),
+        #[cfg(feature = "serde-default")]
+        "serde-default".into(),
+        #[cfg(feature = "bincode")]
+        "bincode".into(),
+        #[cfg(feature = "csv")]
+        "csv".into(),
+        #[cfg(feature = "json")]
+        "json".into(),
+        #[cfg(feature = "toml")]
+        "toml".into(),
+        #[cfg(feature = "yaml")]
+        "yaml".into(),
+    ]
+}
+
 #[macro_use]
 pub mod macros;
 

--- a/fastsim-core/src/pyo3.rs
+++ b/fastsim-core/src/pyo3.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "pyo3")]
-pub use pyo3::exceptions::{
-    PyAttributeError, PyFileNotFoundError, PyNotImplementedError, PyValueError,
-};
+pub use pyo3::exceptions::*;
 pub use pyo3::ffi::{getter, setter};
 pub use pyo3::prelude::*;
 pub use pyo3::types::{PyBytes, PyDict, PyType};

--- a/fastsim-core/src/simdrive.rs
+++ b/fastsim-core/src/simdrive.rs
@@ -361,10 +361,12 @@ impl Default for TraceMissTolerance {
 mod tests {
     use super::*;
     use crate::vehicle::vehicle::tests::*;
+
     #[test]
+    #[cfg(feature = "resources")]
     fn test_sim_drive_conv() {
         let _veh = mock_f2_conv_veh();
-        let _cyc = Cycle::from_resource("cycles/udds.csv").unwrap();
+        let _cyc = Cycle::from_resource("udds.csv", false).unwrap();
         let mut sd = SimDrive {
             veh: _veh,
             cyc: _cyc,
@@ -374,10 +376,12 @@ mod tests {
         assert!(sd.veh.state.i == sd.cyc.len());
         assert!(sd.veh.fc().unwrap().state.energy_fuel > uc::J * 0.);
     }
+
     #[test]
+    #[cfg(feature = "resources")]
     fn test_sim_drive_hev() {
         let _veh = mock_f2_hev();
-        let _cyc = Cycle::from_resource("cycles/udds.csv").unwrap();
+        let _cyc = Cycle::from_resource("udds.csv", false).unwrap();
         let mut sd = SimDrive {
             veh: _veh,
             cyc: _cyc,

--- a/fastsim-core/src/traits.rs
+++ b/fastsim-core/src/traits.rs
@@ -73,54 +73,72 @@ pub trait Init {
     }
 }
 
-// TODO: only call `init` once per deserialization -- @Kyle, has this been solved?
 pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
-    const ACCEPTED_BYTE_FORMATS: &'static [&'static str] = &["yaml", "json", "bin"];
-    const ACCEPTED_STR_FORMATS: &'static [&'static str] = &["yaml", "json"];
+    const ACCEPTED_BYTE_FORMATS: &'static [&'static str] = &[
+        #[cfg(feature = "yaml")]
+        "yaml",
+        #[cfg(feature = "json")]
+        "json",
+        #[cfg(feature = "toml")]
+        "toml",
+        #[cfg(feature = "bincode")]
+        "bin",
+    ];
+    const ACCEPTED_STR_FORMATS: &'static [&'static str] = &[
+        #[cfg(feature = "yaml")]
+        "yaml",
+        #[cfg(feature = "json")]
+        "json",
+        #[cfg(feature = "toml")]
+        "toml",
+    ];
+    const RESOURCE_PREFIX: &'static str = "";
+    #[cfg(feature = "cache")]
+    const CACHE_FOLDER: &'static str = "";
 
     /// Read (deserialize) an object from a resource file packaged with the `fastsim-core` crate
     ///
     /// # Arguments:
     ///
-    /// * `filepath` - Filepath, relative to the top of the `resources` folder, from which to read the object
-    ///
-    fn from_resource<P: AsRef<Path>>(filepath: P) -> anyhow::Result<Self> {
-        let filepath = filepath.as_ref();
+    /// * `filepath` - Filepath, relative to the top of the `resources` folder (excluding any relevant prefix), from which to read the object
+    #[cfg(feature = "resources")]
+    fn from_resource<P: AsRef<Path>>(filepath: P, skip_init: bool) -> anyhow::Result<Self> {
+        let filepath = Path::new(Self::RESOURCE_PREFIX).join(filepath);
         let extension = filepath
             .extension()
             .and_then(OsStr::to_str)
-            .with_context(|| format!("File extension could not be parsed: {filepath:?}"))?
-            .to_lowercase();
-        ensure!(
-            Self::ACCEPTED_BYTE_FORMATS.contains(&extension.as_str()),
-            "Unsupported format {extension:?}, must be one of {:?}",
-            Self::ACCEPTED_BYTE_FORMATS
-        );
+            .with_context(|| format!("File extension could not be parsed: {filepath:?}"))?;
         let file = crate::resources::RESOURCES_DIR
-            .get_file(filepath)
+            .get_file(&filepath)
             .with_context(|| format!("File not found in resources: {filepath:?}"))?;
-        let mut deserialized = match extension.as_str() {
-            "bin" => Self::from_bincode(include_dir::File::contents(file))?,
-            _ => Self::from_str(
-                include_dir::File::contents_utf8(file)
-                    .with_context(|| format!("File could not be parsed to UTF-8: {filepath:?}"))?,
-                &extension,
-            )?,
-        };
-        deserialized
-            .init()
-            .with_context(|| anyhow!(format_dbg!()))?;
-        Ok(deserialized)
+        Self::from_reader(file.contents(), extension, skip_init)
     }
 
-    #[allow(clippy::wrong_self_convention)]
+    /// Instantiates an object from a url.  Accepts yaml and json file types  
+    /// # Arguments  
+    /// - url: URL (either as a string or url type) to object  
+    /// Note: The URL needs to be a URL pointing directly to a file, for example
+    /// a raw github URL.
+    #[cfg(feature = "web")]
+    fn from_url<S: AsRef<str>>(url: S, skip_init: bool) -> anyhow::Result<Self> {
+        let url = url::Url::parse(url.as_ref())?;
+        let format = url
+            .path_segments()
+            .and_then(|segments| segments.last())
+            .and_then(|filename| Path::new(filename).extension())
+            .and_then(OsStr::to_str)
+            .with_context(|| "Could not parse file format from URL: {url:?}")?;
+        let response = ureq::get(url.as_ref()).call()?.into_reader();
+        Self::from_reader(response, format, skip_init)
+    }
+
     /// Write (serialize) an object to a file.
     /// Supported file extensions are listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`).
     /// Creates a new file if it does not already exist, otherwise truncates the existing file.
     ///
     /// # Arguments
     ///
-    /// * `filepath` - The filepath at which write the object
+    /// * `filepath` - The filepath at which to write the object
     ///
     fn to_file<P: AsRef<Path>>(&self, filepath: P) -> anyhow::Result<()> {
         let filepath = filepath.as_ref();
@@ -128,16 +146,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
             .extension()
             .and_then(OsStr::to_str)
             .with_context(|| format!("File extension could not be parsed: {filepath:?}"))?;
-        match extension.trim_start_matches('.').to_lowercase().as_str() {
-            "yaml" | "yml" => serde_yaml::to_writer(&File::create(filepath)?, self)?,
-            "json" => serde_json::to_writer(&File::create(filepath)?, self)?,
-            "bin" => bincode::serialize_into(&File::create(filepath)?, self)?,
-            _ => bail!(
-                "Unsupported format {extension:?}, must be one of {:?}",
-                Self::ACCEPTED_BYTE_FORMATS
-            ),
-        }
-        Ok(())
+        self.to_writer(File::create(filepath)?, extension)
     }
 
     /// Read (deserialize) an object from a file.
@@ -147,7 +156,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
     ///
     /// * `filepath`: The filepath from which to read the object
     ///
-    fn from_file<P: AsRef<Path>>(filepath: P) -> anyhow::Result<Self> {
+    fn from_file<P: AsRef<Path>>(filepath: P, skip_init: bool) -> anyhow::Result<Self> {
         let filepath = filepath.as_ref();
         let extension = filepath
             .extension()
@@ -160,11 +169,70 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
                 format!("Could not open file: {filepath:?}")
             }
         })?;
-        let mut deserialized =
-            Self::from_reader(file, extension).with_context(|| anyhow!(format_dbg!()))?;
-        deserialized
-            .init()
-            .with_context(|| anyhow!(format_dbg!()))?;
+        Self::from_reader(file, extension, skip_init)
+    }
+
+    /// Write (serialize) an object into anything that implements [`std::io::Write`]
+    ///
+    /// # Arguments:
+    ///
+    /// * `wtr` - The writer into which to write object data
+    /// * `format` - The target format, any of those listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`)
+    ///
+    fn to_writer<W: std::io::Write>(&self, mut wtr: W, format: &str) -> anyhow::Result<()> {
+        match format.trim_start_matches('.').to_lowercase().as_str() {
+            #[cfg(feature = "yaml")]
+            "yaml" | "yml" => serde_yaml::to_writer(wtr, self)?,
+            #[cfg(feature = "json")]
+            "json" => serde_json::to_writer(wtr, self)?,
+            #[cfg(feature = "toml")]
+            "toml" => {
+                let toml_string = self.to_toml()?;
+                wtr.write_all(toml_string.as_bytes())?;
+            }
+            #[cfg(feature = "bincode")]
+            "bin" => bincode::serialize_into(wtr, self)?,
+            _ => bail!(
+                "Unsupported format {format:?}, must be one of {:?}",
+                Self::ACCEPTED_BYTE_FORMATS
+            ),
+        }
+        Ok(())
+    }
+
+    /// Deserialize an object from anything that implements [`std::io::Read`]
+    ///
+    /// # Arguments:
+    ///
+    /// * `rdr` - The reader from which to read object data
+    /// * `format` - The source format, any of those listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`)
+    ///
+    fn from_reader<R: std::io::Read>(
+        mut rdr: R,
+        format: &str,
+        skip_init: bool,
+    ) -> anyhow::Result<Self> {
+        let mut deserialized: Self = match format.trim_start_matches('.').to_lowercase().as_str() {
+            #[cfg(feature = "yaml")]
+            "yaml" | "yml" => serde_yaml::from_reader(rdr)?,
+            #[cfg(feature = "json")]
+            "json" => serde_json::from_reader(rdr)?,
+            #[cfg(feature = "tonl")]
+            "toml" => {
+                let mut buf = String::new();
+                rdr.read_to_string(&mut buf)?;
+                Self::from_toml(buf, skip_init)?
+            }
+            #[cfg(feature = "bincode")]
+            "bin" => bincode::deserialize_from(rdr)?,
+            _ => bail!(
+                "Unsupported format {format:?}, must be one of {:?}",
+                Self::ACCEPTED_BYTE_FORMATS
+            ),
+        };
+        if !skip_init {
+            deserialized.init()?;
+        }
         Ok(deserialized)
     }
 
@@ -176,8 +244,12 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
     ///
     fn to_str(&self, format: &str) -> anyhow::Result<String> {
         match format.trim_start_matches('.').to_lowercase().as_str() {
+            #[cfg(feature = "yaml")]
             "yaml" | "yml" => self.to_yaml(),
+            #[cfg(feature = "json")]
             "json" => self.to_json(),
+            #[cfg(feature = "toml")]
+            "toml" => self.to_toml(),
             _ => bail!(
                 "Unsupported format {format:?}, must be one of {:?}",
                 Self::ACCEPTED_STR_FORMATS
@@ -192,65 +264,90 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
     /// * `contents` - The string containing the object data
     /// * `format` - The source format, any of those listed in [`ACCEPTED_STR_FORMATS`](`SerdeAPI::ACCEPTED_STR_FORMATS`)
     ///
-    fn from_str(contents: &str, format: &str) -> anyhow::Result<Self> {
-        let mut deserialized = match format.trim_start_matches('.').to_lowercase().as_str() {
-            "yaml" | "yml" => Self::from_yaml(contents)?,
-            "json" => Self::from_json(contents)?,
-            _ => bail!(
-                "Unsupported format {format:?}, must be one of {:?}",
-                Self::ACCEPTED_STR_FORMATS
-            ),
-        };
-        deserialized
-            .init()
-            .with_context(|| anyhow!(format_dbg!()))?;
-        Ok(deserialized)
+    fn from_str<S: AsRef<str>>(contents: S, format: &str, skip_init: bool) -> anyhow::Result<Self> {
+        Ok(
+            match format.trim_start_matches('.').to_lowercase().as_str() {
+                #[cfg(feature = "yaml")]
+                "yaml" | "yml" => Self::from_yaml(contents, skip_init)?,
+                #[cfg(feature = "json")]
+                "json" => Self::from_json(contents, skip_init)?,
+                #[cfg(feature = "toml")]
+                "toml" => Self::from_toml(contents, skip_init)?,
+                _ => bail!(
+                    "Unsupported format {format:?}, must be one of {:?}",
+                    Self::ACCEPTED_STR_FORMATS
+                ),
+            },
+        )
     }
 
-    /// Deserialize an object from anything that implements [`std::io::Read`]
+    /// Write (serialize) an object to bincode-encoded bytes
+    #[cfg(feature = "bincode")]
+    fn to_bincode(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(bincode::serialize(&self)?)
+    }
+
+    /// Read (deserialize) an object from bincode-encoded bytes
     ///
-    /// # Arguments:
+    /// # Arguments
     ///
-    /// * `rdr` - The reader from which to read object data
-    /// * `format` - The source format, any of those listed in [`ACCEPTED_BYTE_FORMATS`](`SerdeAPI::ACCEPTED_BYTE_FORMATS`)
+    /// * `encoded` - Encoded bytes to deserialize from
     ///
-    fn from_reader<R: std::io::Read>(rdr: R, format: &str) -> anyhow::Result<Self> {
-        let mut deserialized: Self = match format.trim_start_matches('.').to_lowercase().as_str() {
-            "yaml" | "yml" => serde_yaml::from_reader(rdr)?,
-            "json" => serde_json::from_reader(rdr)?,
-            "bin" => bincode::deserialize_from(rdr)?,
-            _ => bail!(
-                "Unsupported format {format:?}, must be one of {:?}",
-                Self::ACCEPTED_BYTE_FORMATS
-            ),
-        };
-        deserialized
-            .init()
-            .with_context(|| anyhow!(format_dbg!()))?;
-        Ok(deserialized)
+    #[cfg(feature = "bincode")]
+    fn from_bincode(encoded: &[u8], skip_init: bool) -> anyhow::Result<Self> {
+        let mut bincode_de: Self = bincode::deserialize(encoded)?;
+        if !skip_init {
+            bincode_de.init()?;
+        }
+        Ok(bincode_de)
     }
 
     /// Write (serialize) an object to a JSON string
+    #[cfg(feature = "json")]
     fn to_json(&self) -> anyhow::Result<String> {
         Ok(serde_json::to_string(&self)?)
     }
 
-    /// Read (deserialize) an object to a JSON string
+    /// Read (deserialize) an object from a JSON string
     ///
     /// # Arguments
     ///
     /// * `json_str` - JSON-formatted string to deserialize from
     ///
-    fn from_json(json_str: &str) -> anyhow::Result<Self> {
-        let mut json_de: Self =
-            serde_json::from_str(json_str).with_context(|| anyhow!(format_dbg!()))?;
-        json_de.init().with_context(|| anyhow!(format_dbg!()))?;
+    #[cfg(feature = "json")]
+    fn from_json<S: AsRef<str>>(json_str: S, skip_init: bool) -> anyhow::Result<Self> {
+        let mut json_de: Self = serde_json::from_str(json_str.as_ref())?;
+        if !skip_init {
+            json_de.init()?;
+        }
         Ok(json_de)
     }
 
+    /// Write (serialize) an object to a TOML string
+    #[cfg(feature = "toml")]
+    fn to_toml(&self) -> anyhow::Result<String> {
+        Ok(toml::to_string(&self)?)
+    }
+
+    /// Read (deserialize) an object from a TOML string
+    ///
+    /// # Arguments
+    ///
+    /// * `toml_str` - TOML-formatted string to deserialize from
+    ///
+    #[cfg(feature = "toml")]
+    fn from_toml<S: AsRef<str>>(toml_str: S, skip_init: bool) -> anyhow::Result<Self> {
+        let mut toml_de: Self = toml::from_str(toml_str.as_ref())?;
+        if !skip_init {
+            toml_de.init()?;
+        }
+        Ok(toml_de)
+    }
+
     /// Write (serialize) an object to a YAML string
+    #[cfg(feature = "yaml")]
     fn to_yaml(&self) -> anyhow::Result<String> {
-        Ok(serde_yaml::to_string(&self).with_context(|| anyhow!(format_dbg!()))?)
+        Ok(serde_yaml::to_string(&self)?)
     }
 
     /// Read (deserialize) an object from a YAML string
@@ -259,29 +356,75 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
     ///
     /// * `yaml_str` - YAML-formatted string to deserialize from
     ///
-    fn from_yaml(yaml_str: &str) -> anyhow::Result<Self> {
-        let mut yaml_de: Self =
-            serde_yaml::from_str(yaml_str).with_context(|| anyhow!(format_dbg!()))?;
-        yaml_de.init().with_context(|| anyhow!(format_dbg!()))?;
+    #[cfg(feature = "yaml")]
+    fn from_yaml<S: AsRef<str>>(yaml_str: S, skip_init: bool) -> anyhow::Result<Self> {
+        let mut yaml_de: Self = serde_yaml::from_str(yaml_str.as_ref())?;
+        if !skip_init {
+            yaml_de.init()?;
+        }
         Ok(yaml_de)
     }
 
-    /// Write (serialize) an object to a bincode-encoded byte array
-    fn to_bincode(&self) -> anyhow::Result<Vec<u8>> {
-        Ok(bincode::serialize(&self)?)
-    }
+    // /// Takes an instantiated Rust object and saves it in the FASTSim data directory in
+    // /// a rust_objects folder.
+    // /// WARNING: If there is a file already in the data subdirectory with the
+    // /// same name, it will be replaced by the new file.
+    // /// # Arguments
+    // /// - self (rust object)
+    // /// - file_path: path to file within subdirectory. If only the file name is
+    // /// listed, file will sit directly within the subdirectory of
+    // /// the FASTSim data directory. If a path is given, the file will live
+    // /// within the path specified, within the subdirectory CACHE_FOLDER of the
+    // /// FASTSim data directory.
+    // #[cfg(feature = "cache")]
+    // fn to_cache<P: AsRef<Path>>(&self, file_path: P) -> anyhow::Result<()> {
+    //     let file_name = file_path
+    //         .as_ref()
+    //         .file_name()
+    //         .with_context(|| "Could not determine file name")?
+    //         .to_str()
+    //         .context("Could not determine file name.")?;
+    //     let file_path_internal = file_path
+    //         .as_ref()
+    //         .to_str()
+    //         .context("Could not determine file name.")?;
+    //     let subpath = if file_name == file_path_internal {
+    //         PathBuf::from(Self::CACHE_FOLDER)
+    //     } else {
+    //         Path::new(Self::CACHE_FOLDER).join(
+    //             file_path_internal
+    //                 .strip_suffix(file_name)
+    //                 .context("Could not determine path to subdirectory.")?,
+    //         )
+    //     };
+    //     let data_subdirectory = create_project_subdir(subpath)
+    //         .with_context(|| "Could not find or build Fastsim data subdirectory.")?;
+    //     let file_path = data_subdirectory.join(file_name);
+    //     self.to_file(file_path)
+    // }
 
-    /// Read (deserialize) an object from a bincode-encoded byte array
-    ///
-    /// # Arguments
-    ///
-    /// * `encoded` - Encoded byte array to deserialize from
-    ///
-    fn from_bincode(encoded: &[u8]) -> anyhow::Result<Self> {
-        let mut bincode_de: Self = deserialize(encoded).with_context(|| anyhow!(format_dbg!()))?;
-        bincode_de.init().with_context(|| anyhow!(format_dbg!()))?;
-        Ok(bincode_de)
-    }
+    // /// Instantiates a Rust object from the subdirectory within the FASTSim data
+    // /// directory corresponding to the Rust Object ("vehices" for a RustVehice,
+    // /// "cycles" for a RustCycle, and the root folder of the data directory for
+    // /// all other objects).
+    // /// # Arguments
+    // /// - file_path: subpath to object, including file name, within subdirectory.
+    // ///   If the file sits directly in the subdirectory, this will just be the
+    // ///   file name.
+    // /// Note: This function will work for all objects cached using the
+    // /// to_cache() method. If a file has been saved manually to a different
+    // /// subdirectory than the correct one for the object type (for instance a
+    // /// RustVehicle saved within a subdirectory other than "vehicles" using the
+    // /// utils::url_to_cache() function), then from_cache() will not be able to
+    // /// find and instantiate the object. Instead, use the from_file method, and
+    // /// use the utils::path_to_cache() to find the FASTSim data directory
+    // /// location if needed.
+    // #[cfg(feature = "cache")]
+    // fn from_cache<P: AsRef<Path>>(file_path: P, skip_init: bool) -> anyhow::Result<Self> {
+    //     let full_file_path = Path::new(Self::CACHE_FOLDER).join(file_path);
+    //     let path_including_directory = path_to_cache()?.join(full_file_path);
+    //     Self::from_file(path_including_directory, skip_init)
+    // }
 }
 
 impl<T: SerdeAPI> SerdeAPI for Vec<T> {}

--- a/fastsim-core/src/traits.rs
+++ b/fastsim-core/src/traits.rs
@@ -94,8 +94,6 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
     ];
     #[cfg(feature = "resources")]
     const RESOURCE_PREFIX: &'static str = "";
-    #[cfg(feature = "cache")]
-    const CACHE_FOLDER: &'static str = "";
 
     /// Read (deserialize) an object from a resource file packaged with the `fastsim-core` crate
     ///
@@ -365,67 +363,6 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
         }
         Ok(yaml_de)
     }
-
-    // /// Takes an instantiated Rust object and saves it in the FASTSim data directory in
-    // /// a rust_objects folder.
-    // /// WARNING: If there is a file already in the data subdirectory with the
-    // /// same name, it will be replaced by the new file.
-    // /// # Arguments
-    // /// - self (rust object)
-    // /// - file_path: path to file within subdirectory. If only the file name is
-    // /// listed, file will sit directly within the subdirectory of
-    // /// the FASTSim data directory. If a path is given, the file will live
-    // /// within the path specified, within the subdirectory CACHE_FOLDER of the
-    // /// FASTSim data directory.
-    // #[cfg(feature = "cache")]
-    // fn to_cache<P: AsRef<Path>>(&self, file_path: P) -> anyhow::Result<()> {
-    //     let file_name = file_path
-    //         .as_ref()
-    //         .file_name()
-    //         .with_context(|| "Could not determine file name")?
-    //         .to_str()
-    //         .context("Could not determine file name.")?;
-    //     let file_path_internal = file_path
-    //         .as_ref()
-    //         .to_str()
-    //         .context("Could not determine file name.")?;
-    //     let subpath = if file_name == file_path_internal {
-    //         PathBuf::from(Self::CACHE_FOLDER)
-    //     } else {
-    //         Path::new(Self::CACHE_FOLDER).join(
-    //             file_path_internal
-    //                 .strip_suffix(file_name)
-    //                 .context("Could not determine path to subdirectory.")?,
-    //         )
-    //     };
-    //     let data_subdirectory = create_project_subdir(subpath)
-    //         .with_context(|| "Could not find or build Fastsim data subdirectory.")?;
-    //     let file_path = data_subdirectory.join(file_name);
-    //     self.to_file(file_path)
-    // }
-
-    // /// Instantiates a Rust object from the subdirectory within the FASTSim data
-    // /// directory corresponding to the Rust Object ("vehices" for a RustVehice,
-    // /// "cycles" for a RustCycle, and the root folder of the data directory for
-    // /// all other objects).
-    // /// # Arguments
-    // /// - file_path: subpath to object, including file name, within subdirectory.
-    // ///   If the file sits directly in the subdirectory, this will just be the
-    // ///   file name.
-    // /// Note: This function will work for all objects cached using the
-    // /// to_cache() method. If a file has been saved manually to a different
-    // /// subdirectory than the correct one for the object type (for instance a
-    // /// RustVehicle saved within a subdirectory other than "vehicles" using the
-    // /// utils::url_to_cache() function), then from_cache() will not be able to
-    // /// find and instantiate the object. Instead, use the from_file method, and
-    // /// use the utils::path_to_cache() to find the FASTSim data directory
-    // /// location if needed.
-    // #[cfg(feature = "cache")]
-    // fn from_cache<P: AsRef<Path>>(file_path: P, skip_init: bool) -> anyhow::Result<Self> {
-    //     let full_file_path = Path::new(Self::CACHE_FOLDER).join(file_path);
-    //     let path_including_directory = path_to_cache()?.join(full_file_path);
-    //     Self::from_file(path_including_directory, skip_init)
-    // }
 }
 
 impl<T: SerdeAPI> SerdeAPI for Vec<T> {}

--- a/fastsim-core/src/traits.rs
+++ b/fastsim-core/src/traits.rs
@@ -92,6 +92,7 @@ pub trait SerdeAPI: Serialize + for<'a> Deserialize<'a> + Init {
         #[cfg(feature = "toml")]
         "toml",
     ];
+    #[cfg(feature = "resources")]
     const RESOURCE_PREFIX: &'static str = "";
     #[cfg(feature = "cache")]
     const CACHE_FOLDER: &'static str = "";

--- a/fastsim-core/src/utils.rs
+++ b/fastsim-core/src/utils.rs
@@ -24,7 +24,10 @@ pub fn is_sorted<T: std::cmp::PartialOrd>(data: &[T]) -> bool {
 /// If supplied filepath has no file extension,
 /// this function will attempt to parse a filename from the last segment of the URL.
 #[cfg(feature = "web")]
-fn download_file<S: AsRef<str>, P: AsRef<Path>>(url: S, filepath: P) -> anyhow::Result<()> {
+pub(crate) fn download_file<S: AsRef<str>, P: AsRef<Path>>(
+    url: S,
+    filepath: P,
+) -> anyhow::Result<()> {
     let url = url::Url::parse(url.as_ref())?;
     let filepath = filepath.as_ref();
     let filepath = if filepath.extension().is_none() {

--- a/fastsim-core/src/utils.rs
+++ b/fastsim-core/src/utils.rs
@@ -19,6 +19,30 @@ pub fn is_sorted<T: std::cmp::PartialOrd>(data: &[T]) -> bool {
     data.windows(2).all(|w| w[0] <= w[1])
 }
 
+/// Download a file to a specified filepath, assuming all necessary parent directories exist.
+///
+/// If supplied filepath has no file extension,
+/// this function will attempt to parse a filename from the last segment of the URL.
+#[cfg(feature = "web")]
+fn download_file<S: AsRef<str>, P: AsRef<Path>>(url: S, filepath: P) -> anyhow::Result<()> {
+    let url = url::Url::parse(url.as_ref())?;
+    let filepath = filepath.as_ref();
+    let filepath = if filepath.extension().is_none() {
+        // No extension in filepath, parse from URL
+        let filename = url
+            .path_segments()
+            .and_then(|segments| segments.last())
+            .with_context(|| "Could not parse filename from last URL segment: {url:?}")?;
+        filepath.join(filename)
+    } else {
+        filepath.to_path_buf()
+    };
+    let mut rdr = ureq::get(url.as_ref()).call()?.into_reader();
+    let mut wtr = File::create(filepath)?;
+    std::io::copy(&mut rdr, &mut wtr)?;
+    Ok(())
+}
+
 /// helper function to find where a query falls on an axis of discrete values;
 /// NOTE: this assumes the axis array is sorted with values ascending and that there are no repeating values!
 fn find_interp_indices(query: &f64, axis: &[f64]) -> anyhow::Result<(usize, usize)> {

--- a/fastsim-core/src/vehicle/vehicle.rs
+++ b/fastsim-core/src/vehicle/vehicle.rs
@@ -873,6 +873,7 @@ pub(crate) mod tests {
         veh
     }
 
+    #[cfg(feature = "yaml")]
     pub(crate) fn mock_f2_hev() -> Vehicle {
         let file_contents = include_str!("fastsim-2_2016_TOYOTA_Prius_Two.yaml");
         use fastsim_2::traits::SerdeAPI;
@@ -904,9 +905,10 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "csv", feature = "resources"))]
     fn test_to_fastsim2_conv() {
         let veh = mock_f2_conv_veh();
-        let cyc = crate::drive_cycle::Cycle::from_resource("cycles/udds.csv").unwrap();
+        let cyc = crate::drive_cycle::Cycle::from_resource("udds.csv", false).unwrap();
         let sd = crate::simdrive::SimDrive {
             veh,
             cyc,
@@ -917,9 +919,10 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "csv", feature = "resources"))]
     fn test_to_fastsim2_hev() {
         let veh = mock_f2_hev();
-        let cyc = crate::drive_cycle::Cycle::from_resource("cycles/udds.csv").unwrap();
+        let cyc = crate::drive_cycle::Cycle::from_resource("udds.csv", false).unwrap();
         let sd = crate::simdrive::SimDrive {
             veh,
             cyc,
@@ -930,6 +933,7 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "yaml")]
     fn test_hev_deserialize() {
         let veh = mock_f2_hev();
 
@@ -937,6 +941,7 @@ pub(crate) mod tests {
             project_root::get_project_root()
                 .unwrap()
                 .join("tests/assets/2016_TOYOTA_Prius_Two.yaml"),
+            false,
         )
         .unwrap();
         assert!(veh == veh_from_file);

--- a/fastsim-core/src/vehicle/vehicle.rs
+++ b/fastsim-core/src/vehicle/vehicle.rs
@@ -224,8 +224,6 @@ impl Mass for Vehicle {
 impl SerdeAPI for Vehicle {
     #[cfg(feature = "resources")]
     const RESOURCE_PREFIX: &'static str = "vehicles";
-    #[cfg(feature = "cache")]
-    const CACHE_FOLDER: &'static str = "vehicles";
 }
 impl Init for Vehicle {
     fn init(&mut self) -> anyhow::Result<()> {

--- a/fastsim-core/src/vehicle/vehicle.rs
+++ b/fastsim-core/src/vehicle/vehicle.rs
@@ -221,7 +221,12 @@ impl Mass for Vehicle {
     }
 }
 
-impl SerdeAPI for Vehicle {}
+impl SerdeAPI for Vehicle {
+    #[cfg(feature = "resources")]
+    const RESOURCE_PREFIX: &'static str = "vehicles";
+    #[cfg(feature = "cache")]
+    const CACHE_FOLDER: &'static str = "vehicles";
+}
 impl Init for Vehicle {
     fn init(&mut self) -> anyhow::Result<()> {
         let _mass = self.mass().with_context(|| anyhow!(format_dbg!()))?;
@@ -852,6 +857,8 @@ impl Init for VehicleState {}
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
+    #[cfg(feature = "yaml")]
     pub(crate) fn mock_f2_conv_veh() -> Vehicle {
         let file_contents = include_str!("fastsim-2_2012_Ford_Fusion.yaml");
         use fastsim_2::traits::SerdeAPI;
@@ -894,8 +901,10 @@ pub(crate) mod tests {
         .unwrap();
         veh
     }
+
     /// tests that vehicle can be initialized and that repeating has no net effect
     #[test]
+    #[cfg(feature = "yaml")]
     pub(crate) fn test_conv_veh_init() {
         let veh = mock_f2_conv_veh();
         let mut veh1 = veh.clone();

--- a/fastsim-py/src/lib.rs
+++ b/fastsim-py/src/lib.rs
@@ -32,5 +32,8 @@ fn fastsim(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Pyo3VecBoolWrapper>()?;
     m.add_function(wrap_pyfunction!(get_rho_air_py, m)?)?;
 
+    // List enabled features
+    m.add_function(wrap_pyfunction!(fastsim_core::enabled_features, m)?)?;
+
     Ok(())
 }

--- a/python/fastsim/demos/demo_conv.py
+++ b/python/fastsim/demos/demo_conv.py
@@ -28,7 +28,7 @@ veh = fsim.Vehicle.from_file(
 veh.save_interval = 1
 
 # load cycle from file
-cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+cyc = fsim.Cycle.from_resource("udds.csv")
 
 # instantiate `SimDrive` simulation object
 sd = fsim.SimDrive(veh, cyc)

--- a/python/fastsim/demos/demo_hev.py
+++ b/python/fastsim/demos/demo_hev.py
@@ -28,7 +28,7 @@ veh = fsim.Vehicle.from_file(
 veh.save_interval = 1
 
 # load cycle from file
-cyc = fsim.Cycle.from_resource("cycles/udds.csv")
+cyc = fsim.Cycle.from_resource("udds.csv")
 
 # instantiate `SimDrive` simulation object
 sd = fsim.SimDrive(veh, cyc)


### PR DESCRIPTION
Port SerdeAPI stuff from FASTSim 2 to FASTSim 3, except for cache stuff

Introduces the feature framework a la FASTSim 2, along with the `enabled_features` function, rewritten in a better way.