### PR TITLE
Add List Resources feature to FASTSim-2 (SerdeAPI tweaks, list_resources)

### DIFF
--- a/python/fastsim/tests/test_resources.py
+++ b/python/fastsim/tests/test_resources.py
@@ -1,0 +1,15 @@
+"""Test getting resource lists via Rust API"""
+import unittest
+
+import fastsim as fsim
+from fastsim import cycle, vehicle
+
+class TestListResources(unittest.TestCase):
+    def test_list_resources_for_cycle(self):
+        "check if list_resources works and yields results for Cycle"
+        c = cycle.Cycle.from_dict({
+            "cycSecs": [0.0, 1.0],
+            "cycMps": [0.0, 0.0]})
+        rc = c.to_rust()
+        resources = rc.list_resources()
+        self.assertTrue(len(resources) > 0)

--- a/python/fastsim/tests/test_resources.py
+++ b/python/fastsim/tests/test_resources.py
@@ -6,10 +6,22 @@ from fastsim import cycle, vehicle
 
 class TestListResources(unittest.TestCase):
     def test_list_resources_for_cycle(self):
-        "check if list_resources works and yields results for Cycle"
+        "check if list_resources works for RustCycle"
         c = cycle.Cycle.from_dict({
             "cycSecs": [0.0, 1.0],
             "cycMps": [0.0, 0.0]})
         rc = c.to_rust()
         resources = rc.list_resources()
         self.assertTrue(len(resources) > 0)
+
+    def test_list_resources_for_vehicles(self):
+        "check if list_resources works for RustVehicle"
+        # NOTE: at the time of writing this test,
+        #       there are no vehicle assets in resources.
+        #       Therefore, we expect to get an empty vector.
+        #       If resources are committed, this test should
+        #       fail and we should use the following assert:
+        #   self.assertTrue(len(resources) > 0)
+        rv = vehicle.Vehicle.from_vehdb(1).to_rust()
+        resources = rv.list_resources()
+        self.assertTrue(len(resources) == 0)

--- a/rust/fastsim-core/src/cycle.rs
+++ b/rust/fastsim-core/src/cycle.rs
@@ -607,6 +607,12 @@ impl RustCycleCache {
     pub fn get_delta_elev_m(&self) -> Vec<f64> {
         self.delta_elev_m().to_vec()
     }
+
+    #[pyo3(name = "list_resources")]
+    /// list available cycle resources
+    pub fn list_resources_py(&self) -> Vec<String> {
+        RustCycle::list_resources()
+    }
 )]
 /// Struct for containing:
 /// * time_s, cycle time, $s$
@@ -652,7 +658,7 @@ impl SerdeAPI for RustCycle {
             "toml" => {
                 let toml_string = self.to_toml()?;
                 wtr.write_all(toml_string.as_bytes())?;
-            },
+            }
             #[cfg(feature = "bincode")]
             "bin" => bincode::serialize_into(wtr, self)?,
             "csv" => {
@@ -709,7 +715,11 @@ impl SerdeAPI for RustCycle {
         )
     }
 
-    fn from_reader<R: std::io::Read>(mut rdr: R, format: &str, skip_init: bool) -> anyhow::Result<Self> {
+    fn from_reader<R: std::io::Read>(
+        mut rdr: R,
+        format: &str,
+        skip_init: bool,
+    ) -> anyhow::Result<Self> {
         let mut deserialized = match format.trim_start_matches('.').to_lowercase().as_str() {
             "yaml" | "yml" => serde_yaml::from_reader(rdr)?,
             "json" => serde_json::from_reader(rdr)?,
@@ -717,7 +727,7 @@ impl SerdeAPI for RustCycle {
                 let mut buf = String::new();
                 rdr.read_to_string(&mut buf)?;
                 Self::from_toml(buf, skip_init)?
-            },
+            }
             #[cfg(feature = "bincode")]
             "bin" => bincode::deserialize_from(rdr)?,
             "csv" => {
@@ -823,7 +833,11 @@ impl RustCycle {
     }
 
     /// Load cycle from CSV string
-    pub fn from_csv_str<S: AsRef<str>>(csv_str: S, name: String, skip_init: bool) -> anyhow::Result<Self> {
+    pub fn from_csv_str<S: AsRef<str>>(
+        csv_str: S,
+        name: String,
+        skip_init: bool,
+    ) -> anyhow::Result<Self> {
         let mut cyc = Self::from_str(csv_str, "csv", skip_init)?;
         cyc.name = name;
         Ok(cyc)

--- a/rust/fastsim-core/src/lib.rs
+++ b/rust/fastsim-core/src/lib.rs
@@ -53,9 +53,6 @@ pub mod vehicle_import;
 pub mod vehicle_thermal;
 pub mod vehicle_utils;
 
-#[cfg(feature = "dev-proc-macros")]
-pub use dev_proc_macros as proc_macros;
-#[cfg(not(feature = "dev-proc-macros"))]
 pub use fastsim_proc_macros as proc_macros;
 
 #[cfg_attr(feature = "pyo3", pyo3imports::pyfunction)]

--- a/rust/fastsim-core/src/resources.rs
+++ b/rust/fastsim-core/src/resources.rs
@@ -2,3 +2,34 @@
 
 use include_dir::{include_dir, Dir};
 pub const RESOURCES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources");
+
+/// List the available resources in the resources directory
+/// - subdir: &str, a subdirectory to choose from the resources directory
+///   if it cannot be resolved, then the top level is used to list resources
+/// NOTE: if you want the top level, a good way to get that is to pass "".
+/// RETURNS: a vector of strings for resources that can be loaded
+pub fn list_resources(subdir: &str) -> Vec<String> {
+    let resources_path = if let Some(rp) = RESOURCES_DIR.get_dir(subdir) {
+        rp
+    } else {
+        &RESOURCES_DIR
+    };
+    let mut file_names: Vec<String> = resources_path
+        .files()
+        .filter_map(|entry| entry.path().file_name()?.to_str().map(String::from))
+        .collect();
+    file_names.sort();
+    file_names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_resources() {
+        let result = list_resources("cycles");
+        assert!(result.len() == 3);
+        assert!(result[0] == "HHDDTCruiseSmooth.csv");
+    }
+}

--- a/rust/fastsim-core/src/resources.rs
+++ b/rust/fastsim-core/src/resources.rs
@@ -5,21 +5,21 @@ pub const RESOURCES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources");
 
 /// List the available resources in the resources directory
 /// - subdir: &str, a subdirectory to choose from the resources directory
-///   if it cannot be resolved, then the top level is used to list resources
-/// NOTE: if you want the top level, a good way to get that is to pass "".
+/// NOTE: if subdir cannot be resolved, returns an empty list
 /// RETURNS: a vector of strings for resources that can be loaded
 pub fn list_resources(subdir: &str) -> Vec<String> {
-    let resources_path = if let Some(rp) = RESOURCES_DIR.get_dir(subdir) {
-        rp
+    if subdir.is_empty() {
+        Vec::<String>::new()
+    } else if let Some(resources_path) = RESOURCES_DIR.get_dir(subdir) {
+        let mut file_names: Vec<String> = resources_path
+            .files()
+            .filter_map(|entry| entry.path().file_name()?.to_str().map(String::from))
+            .collect();
+        file_names.sort();
+        file_names
     } else {
-        &RESOURCES_DIR
-    };
-    let mut file_names: Vec<String> = resources_path
-        .files()
-        .filter_map(|entry| entry.path().file_name()?.to_str().map(String::from))
-        .collect();
-    file_names.sort();
-    file_names
+        Vec::<String>::new()
+    }
 }
 
 #[cfg(test)]
@@ -31,5 +31,11 @@ mod tests {
         let result = list_resources("cycles");
         assert!(result.len() == 3);
         assert!(result[0] == "HHDDTCruiseSmooth.csv");
+        // NOTE: at the time of writing this test, there is no
+        // vehicles subdirectory. The agreed-upon behavior in
+        // that case is that list_resources should return an
+        // empty vector of string.
+        let another_result = list_resources("vehicles");
+        assert!(another_result.len() == 0);
     }
 }

--- a/rust/fastsim-core/src/vehicle.rs
+++ b/rust/fastsim-core/src/vehicle.rs
@@ -83,6 +83,11 @@ lazy_static! {
         self.clone()
     }
 
+    #[pyo3(name = "list_resources")]
+    pub fn list_resources_py(&self) -> Vec<String> {
+        RustVehicle::list_resources()
+    }
+
     #[staticmethod]
     #[pyo3(name = "mock_vehicle")]
     fn mock_vehicle_py() -> Self {
@@ -771,7 +776,8 @@ impl RustVehicle {
                 self.modern_max = MODERN_MAX;
             }
             let modern_diff = self.modern_max - arrmax(&LARGE_BASELINE_EFF);
-            let large_baseline_eff_adj: Vec<f64> = LARGE_BASELINE_EFF.iter().map(|x| x + modern_diff).collect();
+            let large_baseline_eff_adj: Vec<f64> =
+                LARGE_BASELINE_EFF.iter().map(|x| x + modern_diff).collect();
             let mc_kw_adj_perc = max(
                 0.0,
                 min(
@@ -1068,8 +1074,8 @@ impl RustVehicle {
             }
             None => Self::VEHICLE_DIRECTORY_URL.to_string() + vehicle_file_name.as_ref(),
         };
-        let mut vehicle =
-            Self::from_url(&url_internal, false).with_context(|| "Could not parse vehicle from url")?;
+        let mut vehicle = Self::from_url(&url_internal, false)
+            .with_context(|| "Could not parse vehicle from url")?;
         let vehicle_origin = "Vehicle from ".to_owned() + url_internal.as_str();
         vehicle.doc = Some(vehicle_origin);
         Ok(vehicle)

--- a/rust/fastsim-core/src/vehicle.rs
+++ b/rust/fastsim-core/src/vehicle.rs
@@ -83,11 +83,6 @@ lazy_static! {
         self.clone()
     }
 
-    #[pyo3(name = "list_resources")]
-    pub fn list_resources_py(&self) -> Vec<String> {
-        RustVehicle::list_resources()
-    }
-
     #[staticmethod]
     #[pyo3(name = "mock_vehicle")]
     fn mock_vehicle_py() -> Self {

--- a/rust/fastsim-core/src/vehicle.rs
+++ b/rust/fastsim-core/src/vehicle.rs
@@ -83,6 +83,12 @@ lazy_static! {
         self.clone()
     }
 
+    #[pyo3(name = "list_resources")]
+    /// list available vehicle resources
+    pub fn list_resources_py(&self) -> Vec<String> {
+        RustVehicle::list_resources()
+    }
+
     #[staticmethod]
     #[pyo3(name = "mock_vehicle")]
     fn mock_vehicle_py() -> Self {


### PR DESCRIPTION
This is the fastsim-2 implementation to address this issue:
https://github.nrel.gov/MBAP/fastsim/issues/354

The resources::list_resources(subdir) will list all the resources of a given subdirectory. If the subdirectory doesn't exist, an empty vector of string is returned, else the files in that subdirectory.

The SerdeAPI trait connects the RESOURCE_PREFIX with the call to resources::list_resources.

The list_resources_py methods of RustCycle and RustVehicle allow exposure from Python.