### PR TITLE
Update CI Workflow to Skip Network Tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,9 @@ jobs:
           - os: windows
             ls: dir
 
+    env:
+      FASTSIM_DISABLE_NETWORK_TESTS: 1
+
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ jobs:
 
       env:
         PYTHON: ${{ matrix.python-version }}
+        FASTSIM_DISABLE_NETWORK_TESTS: 1
       steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
       env:
         PYTHON: ${{ matrix.python-version }}
         FASTSIM_DISABLE_NETWORK_TESTS: 1
+
       steps:
       - uses: actions/checkout@v3
 

--- a/python/fastsim/demos/test_demos.py
+++ b/python/fastsim/demos/test_demos.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 import os
 from pathlib import Path
@@ -22,8 +23,14 @@ def test_demo(demo_path: Path):
     os.environ["SHOW_PLOTS"] = "false"
     os.environ["TESTING"] = "true"
 
+    # NOTE: Try to set the python executable based on the current running python which
+    # MAY be running from a virtual environment.
+    python_exe = sys.executable
+    if python_exe == "" or python_exe is None:
+        python_exe = "python"
+
     rslt = subprocess.run(
-        ["python", demo_path],
+        [python_exe, demo_path],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/rust/fastsim-core/src/utils.rs
+++ b/rust/fastsim-core/src/utils.rs
@@ -694,6 +694,8 @@ pub use array_wrappers::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vehicle_utils::NETWORK_TEST_DISABLE_ENV_VAR_NAME;
+    use std::env;
 
     #[test]
     fn test_diff() {
@@ -867,6 +869,10 @@ mod tests {
 
     #[test]
     fn test_clear_cache() {
+        if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+            println!("SKIPPING: test_clear_cache");
+            return;
+        }
         let temp_sub_dir = tempfile::TempDir::new_in(create_project_subdir("").unwrap()).unwrap();
         let sub_dir_path = temp_sub_dir.path().to_str().unwrap();
         let still_exists_before = std::fs::metadata(sub_dir_path).is_ok();

--- a/rust/fastsim-core/src/vehicle_import.rs
+++ b/rust/fastsim-core/src/vehicle_import.rs
@@ -337,7 +337,7 @@ pub fn get_options_for_year_make_model(
 #[cfg_attr(feature = "pyo3", pyfunction)]
 pub fn get_vehicle_data_for_id(
     id: i32,
-    year: &str, 
+    year: &str,
     cache_url: Option<String>,
     data_dir: Option<String>,
 ) -> anyhow::Result<VehicleDataFE> {
@@ -348,16 +348,21 @@ pub fn get_vehicle_data_for_id(
         h.insert(y);
         h
     };
-    let ddpath = data_dir.and_then(|dd| Some(PathBuf::from(dd))).unwrap_or(create_project_subdir("fe_label_data")?);
+    let ddpath = data_dir
+        .and_then(|dd| Some(PathBuf::from(dd)))
+        .unwrap_or(create_project_subdir("fe_label_data")?);
     let cache_url = cache_url.unwrap_or_else(get_default_cache_url);
-    populate_cache_for_given_years_if_needed(ddpath.as_path(), &ys, &cache_url).with_context(|| format!("Unable to load or download cache data from {cache_url}"))?;
+    populate_cache_for_given_years_if_needed(ddpath.as_path(), &ys, &cache_url)
+        .with_context(|| format!("Unable to load or download cache data from {cache_url}"))?;
     let emissions_data = load_emissions_data_for_given_years(ddpath.as_path(), &ys)?;
     let fegov_data_by_year =
         load_fegov_data_for_given_years(ddpath.as_path(), &emissions_data, &ys)?;
-    let fegov_db = fegov_data_by_year.get(&y).context(format!("Could not get fueleconomy.gov data from year {y}"))?;
+    let fegov_db = fegov_data_by_year
+        .get(&y)
+        .context(format!("Could not get fueleconomy.gov data from year {y}"))?;
     for item in fegov_db.iter() {
         if item.id == id {
-            return Ok(item.clone())
+            return Ok(item.clone());
         }
     }
     bail!("Could not find ID in data {id}");
@@ -1498,6 +1503,8 @@ fn extract_file_from_zip(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vehicle_utils::NETWORK_TEST_DISABLE_ENV_VAR_NAME;
+    use std::env;
 
     #[test]
     fn test_create_new_vehicle_from_input_data() {
@@ -1612,6 +1619,10 @@ mod tests {
 
     #[test]
     fn test_get_options_for_year_make_model() {
+        if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+            println!("SKIPPING: test_get_options_for_year_make_model");
+            return;
+        }
         let year = String::from("2020");
         let make = String::from("Toyota");
         let model = String::from("Corolla");
@@ -1621,6 +1632,10 @@ mod tests {
 
     #[test]
     fn test_import_robustness() {
+        if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+            println!("SKIPPING: test_import_robustness");
+            return;
+        }
         // Ensure 2019 data is cached
         let ddpath = create_project_subdir("fe_label_data").unwrap();
         let model_year = 2019;
@@ -1691,6 +1706,10 @@ mod tests {
 
     #[test]
     fn test_get_options_for_year_make_model_for_specified_cacheurl_and_data_dir() {
+        if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+            println!("SKIPPING: test_get_options_for_year_make_model_for_specified_cacheurl_and_data_dir");
+            return;
+        }
         let year = String::from("2020");
         let make = String::from("Toyota");
         let model = String::from("Corolla");

--- a/rust/fastsim-core/src/vehicle_utils.rs
+++ b/rust/fastsim-core/src/vehicle_utils.rs
@@ -21,6 +21,8 @@ use crate::simdrive::RustSimDrive;
 #[cfg(feature = "default")]
 use crate::vehicle::RustVehicle;
 
+pub const NETWORK_TEST_DISABLE_ENV_VAR_NAME: &str = "FASTSIM_DISABLE_NETWORK_TESTS";
+
 #[allow(non_snake_case)]
 #[cfg_attr(feature = "pyo3", pyfunction)]
 #[allow(clippy::too_many_arguments)]
@@ -311,6 +313,7 @@ pub fn fetch_github_list(repo_url: Option<String>) -> anyhow::Result<Vec<String>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
 
     #[test]
     fn test_get_error_val() {
@@ -357,6 +360,10 @@ mod tests {
     // there's any way to ensure the function succeeds 100% of the time.
     #[test]
     fn test_fetch_github_list() {
+        if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+            println!("SKIPPING: test_fetch_github_list");
+            return;
+        }
         let list = fetch_github_list(Some(
             "https://api.github.com/repos/NREL/fastsim-vehicles/contents".to_owned(),
         ))

--- a/rust/fastsim-core/tests/integration-tests.rs
+++ b/rust/fastsim-core/tests/integration-tests.rs
@@ -1,6 +1,8 @@
+use std::env;
 use std::path::Path;
 
 use fastsim_core::traits::*;
+use fastsim_core::vehicle_utils::NETWORK_TEST_DISABLE_ENV_VAR_NAME;
 use fastsim_core::*;
 
 const REFERENCE_VEHICLE: &str = include_str!("assets/1110_2022_Tesla_Model_Y_RWD_opt45017.yaml");
@@ -38,6 +40,10 @@ fn test_to_cache() {
 
 #[test]
 fn test_url_to_cache() {
+    if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+        println!("SKIPPING: test_url_to_cache()");
+        return;
+    }
     utils::url_to_cache("https://raw.githubusercontent.com/NREL/fastsim-vehicles/main/assets/2022_Tesla_Model_Y_RWD_example.yaml", "vehicles").unwrap();
     let data_subdirectory = utils::create_project_subdir("vehicles").unwrap();
     let file_path = data_subdirectory.join("2022_Tesla_Model_Y_RWD_example.yaml");
@@ -51,6 +57,10 @@ fn test_url_to_cache() {
 
 #[test]
 fn test_from_github_or_url() {
+    if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+        println!("SKIPPING: test_from_github_or_url()");
+        return;
+    }
     let mut comparison_vehicle = vehicle::RustVehicle::from_yaml(REFERENCE_VEHICLE, false).unwrap();
     comparison_vehicle.doc = Some("Vehicle from https://raw.githubusercontent.com/NREL/fastsim-vehicles/main/assets/2022_Tesla_Model_Y_RWD_example.yaml".to_owned());
     // test no url provided
@@ -77,6 +87,10 @@ fn test_from_github_or_url() {
 
 #[test]
 fn test_from_url() {
+    if env::var(NETWORK_TEST_DISABLE_ENV_VAR_NAME).is_ok() {
+        println!("SKIPPING: test_from_url()");
+        return;
+    }
     let vehicle = vehicle::RustVehicle::from_url("https://raw.githubusercontent.com/NREL/fastsim-vehicles/main/assets/2022_Tesla_Model_Y_RWD_example.yaml", false).unwrap();
     let mut comparison_vehicle = vehicle::RustVehicle::from_yaml(REFERENCE_VEHICLE, false).unwrap();
     comparison_vehicle.doc = Some("Vehicle from https://raw.githubusercontent.com/NREL/fastsim-vehicles/main/assets/2022_Tesla_Model_Y_RWD_example.yaml".to_owned());


### PR DESCRIPTION
This PR sets an environment variable in the CI to skip tests that require network access since the network unreliability on the CI can cause false positive failures.

This commit also addresses an issue where demo tests were not running when called from a venv that had FASTSim installed.

NOTE: there was a previous version of this PR that accidentally brought in the v2.1.3 changes as well. That was deleted and this one was made.