### PR TITLE
F3/spec rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-
+rust-version = "1.83"
 
 [profile.dev]
 opt-level = 0

--- a/fastsim-cli/Cargo.toml
+++ b/fastsim-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fastsim-cli"
 version = "1.0.0"
 edition.workspace = true
+rust-version = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fastsim-core/Cargo.toml
+++ b/fastsim-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fastsim-core"
 version = "1.0.0"
 edition = { workspace = true }
+rust-version = { workspace = true }
 
 [dependencies]
 fastsim-proc-macros = { path = "fastsim-proc-macros", version = "3.0.0" }

--- a/fastsim-py/Cargo.toml
+++ b/fastsim-py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fastsim-py"
 version = "1.0.0"
 edition = { workspace = true }
+rust-version = { workspace = true  }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
mandates rust version 1.83 or newer for all crates

@kylecarow, @robinsteuteville

I've repeatedly run into problems where collaborators have not run `rustup update` in a long time and compilation fails because of stuff that requires a newer compiler version than what they have, and it's always a challenging mystery.  This PR should solve that!   It'd be helpful if you could:
1. run `rustc --version` and proceed with the next step if it's less than 1.83 but __do not run `rustup update`__
1. checkout the branch from this PR
1. try to build
1. share the error message in a comment below and tag me

Only one of y'all needs to do this.

@kylecarow, thoughts on propagating this to fastsim-2?  If yes, from fastsim-2, you could *probably* run `git cherry-pick <latest commit hash in this PR>`