### PR TITLE
updating cal_bev.py to bring it up to speed with cal_hev.py

### DIFF
--- a/cal_and_val/thermal/cal_bev.py
+++ b/cal_and_val/thermal/cal_bev.py
@@ -173,15 +173,15 @@ cal_mod_obj = fsim.pymoo_api.ModelObjectives(
     dfs = dfs_for_cal,
     obj_fns=(
         (
-            lambda sd_dict: np.array(sd_dict['veh']['pt_type']['BatteryElectricVehicle']['res']['history']['soc']),
+            lambda sd_df: np.array(sd_df['veh.pt_type.BatteryElectricVehicle.res.history.soc']),
             lambda df: df['HVBatt_SOC_CAN4__per']
         ),
         # TODO: add objectives for:
         # - battery temperature
         (
-            lambda sd_dict: np.array(sd_dict['veh']['pt_type']['BatteryElectricVehicle']['res']['thermal']['RESLumpedThermal']['history']['temperature_kelvin']),
+            lambda sd_df: np.array(sd_df['veh.pt_type.BatteryElectricVehicle.res.thermal.RESLumpedThermal.history.temperature_kelvin']),
             # HVBatt_cell_temp_1_CAN3__C (or average of temps?) or HVBatt_pack_average_temp_HPCM2__C?
-            lambda df: df['HVBatt_pack_average_temp_HPCM2__C']
+            lambda df: df['HVBatt_pack_average_temp_HPCM2__C'] + celsius_to_kelvin_offset
         ),
         # - cabin temperature
         # - HVAC power, if available

--- a/cal_and_val/thermal/cal_bev.py
+++ b/cal_and_val/thermal/cal_bev.py
@@ -76,7 +76,6 @@ def df_to_cyc(df: pd.DataFrame) -> fsim.Cycle:
         "temp_amb_air_kelvin": (df["Cell_Temp[C]"] + celsius_to_kelvin_offset).to_list(),
         # TODO: pipe solar load from `Cycle` into cabin thermal model
         # TODO: use something (e.g. regex) to determine solar load
-        # see column J comments in 2021_Hyundai_Sonata_Hybrid_TestSummary_2022-03-01_D3.xlsx
         # "pwr_solar_load_watts": df[],
     }
     return fsim.Cycle.from_pydict(cyc_dict, skip_init=False)
@@ -91,8 +90,6 @@ def veh_init(cyc_file_stem: str, dfs: Dict[str, pd.DataFrame]) -> fsim.Vehicle:
         dfs[cyc_file_stem]["Cabin_Temp[C]"][0] + celsius_to_kelvin_offset
     # initialize battery temperature to match cabin temperature because battery
     # temperature is not available in test data
-    # Also, battery temperature has no effect in the HEV because efficiency data
-    # does not go below 23*C and there is no active thermal management
     veh_dict['pt_type']['BatteryElectricVehicle']['res']['thrml']['RESLumpedThermal']['state']['temperature_kelvin'] = \
         dfs[cyc_file_stem]["Cabin_Temp[C]"][0] + celsius_to_kelvin_offset
     # initialize engine temperature

--- a/cal_and_val/thermal/cal_bev.py
+++ b/cal_and_val/thermal/cal_bev.py
@@ -84,7 +84,7 @@ def veh_init(cyc_file_stem: str, dfs: Dict[str, pd.DataFrame]) -> fsim.Vehicle:
     # initialize SOC
     # TODO: figure out if `HVBatt_SOC_CAN4__per` is the correct column within the dyno data
     veh_dict['pt_type']['BatteryElectricVehicle']['res']['state']['soc'] = \
-        dfs[cyc_file_stem]["HVBatt_SOC_CAN4__per"][0]
+        dfs[cyc_file_stem]["HVBatt_SOC_CAN4__per"][0] / 100
     # initialize cabin temp
     veh_dict['cabin']['LumpedCabin']['state']['temperature_kelvin'] = \
         dfs[cyc_file_stem]["Cabin_Temp[C]"][0] + celsius_to_kelvin_offset


### PR DESCRIPTION
I updated everything I could in `cal_bev.py`. A couple notes of places where I was unsure:
1. I didn't populate [cyc_files_for_cal](https://github.com/NREL/fastsim/blob/9d9b10a7bfdbd74a8a267ff535f0cc614606a241/cal_and_val/thermal/cal_bev.py#L62) since I wasn't sure which files you would want to have for the calibration vs. validation. Note that unlike the Hyundai HEV files, the Bolt files seem to combine multiple different scenarios within the same text file -- not sure if this changes how we need to handle things.
2. In the `veh_init()` function, I replaced the Hyundai data header [HVBatt_SOC_high_precision_PCAN__per](https://github.com/NREL/fastsim/blob/9d9b10a7bfdbd74a8a267ff535f0cc614606a241/cal_and_val/thermal/cal_hev.py#L107) with a similar column name from the Bolt data, [HVBatt_SOC_CAN4__per](https://github.com/NREL/fastsim/blob/9d9b10a7bfdbd74a8a267ff535f0cc614606a241/cal_and_val/thermal/cal_bev.py#L88). I'm not positive this is the correct column, but from what I could tell it was the only column in the Bolt .txt files that included SOC in the column name.