### PR TITLE
Fix for breaking change in actions/upload-artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,6 +112,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: fastsim-${{ matrix.platform || matrix.os }}-py3.${{ matrix.python-version }}
           path: ./dist/*
 
   release:
@@ -121,6 +122,8 @@ jobs:
     steps:
       - name: download files
         uses: actions/download-artifact@v4
+        with:
+          name: fastsim-linux-py3.10
 
       - name: set up Python 3.10
         uses: actions/setup-python@v4


### PR DESCRIPTION
Previously, upload-artifact would allow use of
the same name from multiple build configurations.
That has changed, however, and now upload-artifact requires unique names for all uploads.

The corresponding download-artifact has been updated accordingly to download the correct artifact.

For more information:
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes