### PR TITLE
Update release.yaml to match latest from fastsim-3.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     types: [published]
   workflow_dispatch:
 
+# NOTE: parts inspired by https://cibuildwheel.pypa.io/en/stable/setup/
+
 jobs:
   build:
     name: build py3.${{ matrix.python-version }} on ${{ matrix.platform || matrix.os }}
@@ -12,69 +14,72 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-13 # Intel runner
+          - macos-latest # Apple Silicon runner
+          - windows-latest
         python-version:
-          - "9"
           - "10"
           - "11"
         include:
-          - os: ubuntu
+          - os: ubuntu-latest
             platform: linux
-          - os: windows
+          - os: windows-latest
             ls: dir
 
     env:
       FASTSIM_DISABLE_NETWORK_TESTS: 1
 
-    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: set up rust
-        if: matrix.os != 'ubuntu'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
-      - run: rustup target add aarch64-apple-darwin
-        if: matrix.os == 'macos'
+      - name: install rust target for MacOS 14+ (Apple Silicon)
+        run: rustup target add aarch64-apple-darwin
+        if: matrix.os == 'macos-latest'
+
+      - name: install rust target for MacOS 13 (Intl Mac)
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
+        if: matrix.os == 'macos-13'
 
       - name: run cargo tests
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: cd rust/ && cargo test
+        run: cd rust/ && cargo test
 
       - name: set up python
         uses: actions/setup-python@v4
         with:
+          # NOTE: future versions of cibuildwheel need python 3.11+
           python-version: "3.10"
 
+      - name: Upgrade to latest pip
+        run: python -m pip install --upgrade pip
+
       - name: install Python dependencies
-        run: pip install -U setuptools wheel twine cibuildwheel pytest
+        run: python -m pip install --upgrade setuptools wheel twine cibuildwheel pytest
 
       - name: build source distribution
-        if: matrix.os == 'ubuntu' && matrix.python-version == '10'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '10'
         run: |
           pip install -U setuptools-rust
           python -c "import setuptools; setuptools.setup()" sdist
 
+      - name: Update minimum supported MacOS for Wheels for MacOS 13 (Intel Mac)
+        run: echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> $GITHUB_ENV
+        if: matrix.os == 'macos-13'
+
       - name: build ${{ matrix.platform || matrix.os }} binaries
-        run: cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: "cp3${{ matrix.python-version }}-*"
           CIBW_SKIP: "*-win32 *-musllinux* *i686 *ppc64le *s390x *aarch64"
-          CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}
+          # CIBW_PLATFORM: ${{ matrix.platform || matrix.os }}
           # TODO: why doesn't pytest work with cibuildwheel?
           # CIBW_TEST_COMMAND: "pytest -v {project}/python/fastsim/tests"
           CIBW_TEST_COMMAND: "python -m unittest discover {project}/python/fastsim/tests"
-          CIBW_ARCHS_MACOS: "universal2"
+          # CIBW_ARCHS_MACOS: "universal2"
           # see https://cibuildwheel.readthedocs.io/en/stable/faq/#universal2
           CIBW_TEST_SKIP: "*_universal2:arm64"
           CIBW_ENVIRONMENT: 'PATH="$HOME/.cargo/bin:$PATH"'
@@ -92,41 +97,50 @@ jobs:
             rustup show
           CIBW_BEFORE_BUILD_MACOS: >
             rustup target add x86_64-apple-darwin
-      # - name: build windows 32bit binaries
-      #   if: matrix.os == 'windows'
-      #   run: cibuildwheel --output-dir dist
-      #   env:
-      #     CIBW_BUILD: 'cp3${{ matrix.python-version }}-win32'
-      #     CIBW_PLATFORM: windows
-      #     CIBW_TEST_REQUIRES: 'pytest'
-      #     CIBW_TEST_COMMAND: 'pytest {project}/tests -s'
-      #     CIBW_ENVIRONMENT: 'PATH="$UserProfile\.cargo\bin;$PATH"'
-      #     CIBW_BEFORE_BUILD: >
-      #       pip install -U setuptools-rust &&
-      #       rustup toolchain install nightly-i686-pc-windows-msvc &&
-      #       rustup default nightly-i686-pc-windows-msvc &&
-      #       rustup override set nightly-i686-pc-windows-msvc &&
-      #       rustup show
+          # - name: build windows 32bit binaries
+          #   if: matrix.os == 'windows'
+          #   run: cibuildwheel --output-dir dist
+          #   env:
+          #     CIBW_BUILD: 'cp3${{ matrix.python-version }}-win32'
+          #     CIBW_PLATFORM: windows
+          #     CIBW_TEST_REQUIRES: 'pytest'
+          #     CIBW_TEST_COMMAND: 'pytest {project}/tests -s'
+          #     CIBW_ENVIRONMENT: 'PATH="$UserProfile\.cargo\bin;$PATH"'
+          #     CIBW_BEFORE_BUILD: >
+          #       pip install -U setuptools-rust &&
+          #       rustup toolchain install nightly-i686-pc-windows-msvc &&
+          #       rustup default nightly-i686-pc-windows-msvc &&
+          #       rustup override set nightly-i686-pc-windows-msvc &&
+          #       rustup show
 
-      - name: list dist files
-        run: ${{ matrix.ls || 'ls -lh' }} dist/
+      - name: list wheelhouse files
+        run: ${{ matrix.ls || 'ls -lh' }} ./wheelhouse/
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ./dist/*
+          name: artifact-py3.${{ matrix.python-version }}-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
 
   release:
     needs: build
     name: release files to PyPI
     runs-on: ubuntu-latest
+    # Protection Strategies -- use ONE of the following two lines:
+    # publish on via explicit publish
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # publish on tag starting w/ 'v'
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: download files
         uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifact
 
-      - name: set up Python 3.10
+      - name: set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - run: pip install twine
 


### PR DESCRIPTION
The only change from what's on fastsim-3 is in
the call for `cargo test` as we need to cd into
the rust directory on fastsim-2. Otherwise, they
are the same.