### PR TITLE
More small adjustments to the deploy_docs.yaml workflow

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -28,6 +28,10 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    env:
+      # Disable HTTP/2 multiplexing to avoid intermittent crates.io download
+      # failures
+      CARGO_HTTP_MULTIPLEXING: "false"
     steps:
       - uses: actions/checkout@v4
 
@@ -65,6 +69,10 @@ jobs:
 
       - name: Build with Jupyter Book
         working-directory: docs
+        # GitHub Pages serves this project site under /<repo>, so MyST needs the
+        # base path to build correct links to its static assets.
+        env:
+          BASE_URL: "/${{ github.event.repository.name }}"
         # TODO: consider adding --strict once a strict + execute build is
         # confirmed clean, so broken links/refs and execution errors fail the
         # deploy instead of silently publishing.


### PR DESCRIPTION
I've added the same multiplexing fix to `deploy_docs.yaml` found in the `build_and_test.yaml` to avoid http errors with cargo and added a base url fix to prevent github page rendering issues. Hopefully this will be the last fix that we need!