### PR TITLE
Alternator efficiency for HEVs (applies fc aux load only)

### DIFF
--- a/cal_and_val/f3-vehicles/2010 Mazda 3 i-Stop.yaml
+++ b/cal_and_val/f3-vehicles/2010 Mazda 3 i-Stop.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2012 Ford Focus.yaml
+++ b/cal_and_val/f3-vehicles/2012 Ford Focus.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2012 Ford Fusion.yaml
+++ b/cal_and_val/f3-vehicles/2012 Ford Fusion.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 AUDI A3 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 AUDI A3 4cyl 2WD.yaml
@@ -14,7 +14,7 @@ pt_type:
       thrml: None
       mass_kilograms: ~
       specific_pwr_watts_per_kilogram: ~
-      pwr_out_max_watts: 126000.0
+      pwr_out_max_watts: 112000.0
       pwr_out_max_init_watts: 18666.666666666668
       pwr_ramp_lag_seconds: 6.0
       eff_interp_from_pwr_out:
@@ -136,9 +136,9 @@ chassis:
   wheel_radius_meters: 0.336
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.8
+  wheel_fric_coef: 0.7
   drive_type: FWD
-  drive_axle_weight_frac: 0.61
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 BMW 328d 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 BMW 328d 4cyl 2WD.yaml
@@ -136,9 +136,9 @@ chassis:
   wheel_radius_meters: 0.336
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.8
-  drive_type: RWD
-  drive_axle_weight_frac: 0.61
+  wheel_fric_coef: 0.7
+  drive_type: FWD
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 BMW i3 REx PHEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 BMW i3 REx PHEV.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Malibu 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Malibu 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Spark EV.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Spark EV.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Volt.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Volt.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 FORD C-MAX (PHEV).yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD C-MAX (PHEV).yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 FORD C-MAX HEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD C-MAX HEV.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 FORD Escape 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD Escape 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 FORD Explorer 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD Explorer 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 HYUNDAI Elantra 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 HYUNDAI Elantra 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 HYUNDAI Sonata PHEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 HYUNDAI Sonata PHEV.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 Hyundai Tucson Fuel Cell.yaml
+++ b/cal_and_val/f3-vehicles/2016 Hyundai Tucson Fuel Cell.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 KIA Optima Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2016 KIA Optima Hybrid.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 Leaf 24 kWh.yaml
+++ b/cal_and_val/f3-vehicles/2016 Leaf 24 kWh.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 MITSUBISHI i-MiEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 MITSUBISHI i-MiEV.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 Nissan Leaf 30 kWh.yaml
+++ b/cal_and_val/f3-vehicles/2016 Nissan Leaf 30 kWh.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 TESLA Model S60 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TESLA Model S60 2WD.yaml
@@ -207,7 +207,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.336
   tire_code: ~
-  cg_height_meters: -0.445
+  cg_height_meters: 0.445
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Camry 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Camry 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Corolla 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Corolla 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Highlander Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Highlander Hybrid.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2016 Toyota Prius Two FWD.yaml
+++ b/cal_and_val/f3-vehicles/2016 Toyota Prius Two FWD.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2017 CHEVROLET Bolt.yaml
+++ b/cal_and_val/f3-vehicles/2017 CHEVROLET Bolt.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2017 Maruti Dzire VDI.yaml
+++ b/cal_and_val/f3-vehicles/2017 Maruti Dzire VDI.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2017 Prius Prime.yaml
+++ b/cal_and_val/f3-vehicles/2017 Prius Prime.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2017 Toyota Highlander 3.5 L.yaml
+++ b/cal_and_val/f3-vehicles/2017 Toyota Highlander 3.5 L.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2020 Chevrolet Colorado 2WD Diesel.yaml
+++ b/cal_and_val/f3-vehicles/2020 Chevrolet Colorado 2WD Diesel.yaml
@@ -137,7 +137,7 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.7
-  drive_type: RWD
+  drive_type: FWD
   drive_axle_weight_frac: 0.61
   wheel_base_meters: 3.26
   mass_kilograms: ~
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2020 Hero Splendor+ 100cc.yaml
+++ b/cal_and_val/f3-vehicles/2020 Hero Splendor+ 100cc.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2020 VW Golf 1.5TSI.yaml
+++ b/cal_and_val/f3-vehicles/2020 VW Golf 1.5TSI.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2020 VW Golf 2.0TDI.yaml
+++ b/cal_and_val/f3-vehicles/2020 VW Golf 2.0TDI.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2021 BMW iX xDrive40.yaml
+++ b/cal_and_val/f3-vehicles/2021 BMW iX xDrive40.yaml
@@ -207,7 +207,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.395
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
   drive_type: RWD
   drive_axle_weight_frac: 0.61
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2021 Cupra Born.yaml
+++ b/cal_and_val/f3-vehicles/2021 Cupra Born.yaml
@@ -207,7 +207,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.3488
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
   drive_type: RWD
   drive_axle_weight_frac: 0.61
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2021 Fiat Panda Mild Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2021 Fiat Panda Mild Hybrid.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2021 Honda N-Box G.yaml
+++ b/cal_and_val/f3-vehicles/2021 Honda N-Box G.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2021 Peugot 3008.yaml
+++ b/cal_and_val/f3-vehicles/2021 Peugot 3008.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Ford F-150 Lightning 4WD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Ford F-150 Lightning 4WD.yaml
@@ -207,10 +207,10 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.4169
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: RWD
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 MINI Cooper SE Hardtop 2 door.yaml
+++ b/cal_and_val/f3-vehicles/2022 MINI Cooper SE Hardtop 2 door.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Renault Megane E-Tech.yaml
+++ b/cal_and_val/f3-vehicles/2022 Renault Megane E-Tech.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Renault Zoe ZE50 R135.yaml
+++ b/cal_and_val/f3-vehicles/2022 Renault Zoe ZE50 R135.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Tesla Model 3 RWD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Tesla Model 3 RWD.yaml
@@ -207,7 +207,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.33435
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Tesla Model Y RWD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Tesla Model Y RWD.yaml
@@ -207,7 +207,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.36295
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Toyota RAV4 Hybrid LE.yaml
+++ b/cal_and_val/f3-vehicles/2022 Toyota RAV4 Hybrid LE.yaml
@@ -213,7 +213,7 @@ pt_type:
               - 0.93
         strategy: Linear
         extrapolate: Error
-      pwr_out_max_watts: 25000.0
+      pwr_out_max_watts: 128000.0
       specific_pwr_watts_per_kilogram: ~
       mass_kilograms: ~
       save_interval: 1
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 0.9
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -333,10 +334,10 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.36215
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: RWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.68986
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Toyota Yaris Hybrid Mid.yaml
+++ b/cal_and_val/f3-vehicles/2022 Toyota Yaris Hybrid Mid.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 0.9
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2022 Volvo XC40 Recharge twin.yaml
+++ b/cal_and_val/f3-vehicles/2022 Volvo XC40 Recharge twin.yaml
@@ -209,8 +209,8 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.702
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2023 Mitsubishi Pajero Sport.yaml
+++ b/cal_and_val/f3-vehicles/2023 Mitsubishi Pajero Sport.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2023 Polestar 2 Long range Dual motor.yaml
+++ b/cal_and_val/f3-vehicles/2023 Polestar 2 Long range Dual motor.yaml
@@ -209,8 +209,8 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.73558
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2023 Volvo C40 Recharge.yaml
+++ b/cal_and_val/f3-vehicles/2023 Volvo C40 Recharge.yaml
@@ -208,9 +208,9 @@ chassis:
   wheel_radius_meters: 0.356
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.7
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  wheel_fric_coef: 0.8
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.702
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2024 BYD Dolphin Active.yaml
+++ b/cal_and_val/f3-vehicles/2024 BYD Dolphin Active.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2024 Toyota Vios 1.5 G.yaml
+++ b/cal_and_val/f3-vehicles/2024 Toyota Vios 1.5 G.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2024 VinFast VF e34.yaml
+++ b/cal_and_val/f3-vehicles/2024 VinFast VF e34.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/2024 Volkswagen Polo 1.0 MPI.yaml
+++ b/cal_and_val/f3-vehicles/2024 Volkswagen Polo 1.0 MPI.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/BYD ATTO 3.yaml
+++ b/cal_and_val/f3-vehicles/BYD ATTO 3.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Bajaj Boxer 150.yaml
+++ b/cal_and_val/f3-vehicles/Bajaj Boxer 150.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Class 4 Truck (Isuzu NPR HD).yaml
+++ b/cal_and_val/f3-vehicles/Class 4 Truck (Isuzu NPR HD).yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Line Haul Conv.yaml
+++ b/cal_and_val/f3-vehicles/Line Haul Conv.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Maruti Swift 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/Maruti Swift 4cyl 2WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Nissan Navara.yaml
+++ b/cal_and_val/f3-vehicles/Nissan Navara.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Regional Delivery Class 8 Truck.yaml
+++ b/cal_and_val/f3-vehicles/Regional Delivery Class 8 Truck.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Renault Clio IV diesel.yaml
+++ b/cal_and_val/f3-vehicles/Renault Clio IV diesel.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Renault Megane 1.5 dCi Authentique.yaml
+++ b/cal_and_val/f3-vehicles/Renault Megane 1.5 dCi Authentique.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Toyota Corolla Cross Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Corolla Cross Hybrid.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 0.9
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Toyota Etios Liva diesel.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Etios Liva diesel.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Toyota Hilux Double Cab 4WD.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Hilux Double Cab 4WD.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/f3-vehicles/Toyota Mirai.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Mirai.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/cal_and_val/thermal/f3-vehicles/2021_Hyundai_Sonata_Hybrid_Blue.yaml
+++ b/cal_and_val/thermal/f3-vehicles/2021_Hyundai_Sonata_Hybrid_Blue.yaml
@@ -278,6 +278,7 @@ pt_type:
         temp_fc_forced_on_kelvin: 335.15
         temp_fc_allowed_off_kelvin: 338.15
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005

--- a/docs/demo_scripts/vehicle_controls/demo_stop_start.py
+++ b/docs/demo_scripts/vehicle_controls/demo_stop_start.py
@@ -324,6 +324,7 @@ def conv_to_micro_hybrid(
             "transmission": veh_dict["pt_type"]["Conv"]["transmission"],
             "pt_cntrl": pt_cntrl,
             "aux_cntrl": "AuxOnResPriority",
+            "alt_eff": veh_dict["pt_type"]["Conv"]["alt_eff"],
             "mass_kilograms": None,
             "sim_params": sim_params,
         },

--- a/fastsim-core/resources/vehicles/2012_Ford_Fusion.yaml
+++ b/fastsim-core/resources/vehicles/2012_Ford_Fusion.yaml
@@ -152,6 +152,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -182,6 +183,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/fastsim-core/resources/vehicles/2016_TOYOTA_Prius_Two.yaml
+++ b/fastsim-core/resources/vehicles/2016_TOYOTA_Prius_Two.yaml
@@ -317,6 +317,7 @@ pt_type:
           charging_for_low_soc: []
           soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005
@@ -350,6 +351,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -380,6 +382,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/fastsim-core/resources/vehicles/2021_Hyundai_Sonata_Hybrid_Blue_thrml.yaml
+++ b/fastsim-core/resources/vehicles/2021_Hyundai_Sonata_Hybrid_Blue_thrml.yaml
@@ -278,6 +278,7 @@ pt_type:
         temp_fc_forced_on_kelvin: 335.15
         temp_fc_allowed_off_kelvin: 338.15
     aux_cntrl: AuxOnResPriority
+    alt_eff: 1.0
     mass_kilograms: ~
     sim_params:
       res_per_fuel_lim: 0.005

--- a/fastsim-core/resources/vehicles/2022_Renault_Zoe_ZE50_R135.yaml
+++ b/fastsim-core/resources/vehicles/2022_Renault_Zoe_ZE50_R135.yaml
@@ -224,6 +224,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -254,6 +255,7 @@ history:
   i: []
   time_seconds: []
   pwr_prop_fwd_max_watts: []
+  speed_trac_fwd_max_meters_per_second: []
   pwr_prop_bwd_max_watts: []
   pwr_tractive_watts: []
   pwr_tractive_for_cyc_watts: []

--- a/fastsim-core/src/vehicle/2021_Hyundai_Sonata_Hybrid_Blue.yaml
+++ b/fastsim-core/src/vehicle/2021_Hyundai_Sonata_Hybrid_Blue.yaml
@@ -1,0 +1,324 @@
+---
+name: 2021 Hyundai Sonata Hybrid Blue
+year: 2021
+pt_type:
+  HybridElectricVehicle:
+    res:
+      thrml:
+        RESLumpedThermal:
+          heat_capacitance_joules_per_kelvin: 200000.0
+          conductance_to_amb_watts_per_kelvin: 0.1
+          conductance_to_cab_watts_per_kelvin: 0.5
+      mass_kilograms: ~
+      specific_energy_joules_per_kilogram: ~
+      pwr_out_max_watts: 50000.0
+      energy_capacity_joules: 5760000.0
+      eff_interp:
+        CRateTemperature:
+          data:
+            grid:
+              - v: 1
+                dim:
+                  - 11
+                data:
+                  - -5.0
+                  - -3.0
+                  - -1.0
+                  - -0.5
+                  - -0.1
+                  - 0.1
+                  - 0.5
+                  - 1.0
+                  - 2.0
+                  - 3.0
+                  - 5.0
+              - v: 1
+                dim:
+                  - 4
+                data:
+                  - 23.0
+                  - 30.0
+                  - 45.0
+                  - 55.0
+            values:
+              v: 1
+              dim:
+                - 11
+                - 4
+              data:
+                - 0.892085814015878
+                - 0.91092
+                - 0.929788
+                - 0.929788
+                - 0.935630351894604
+                - 0.946773
+                - 0.957986
+                - 0.957986
+                - 0.978612548997097
+                - 0.982298
+                - 0.986015
+                - 0.986015
+                - 0.989309767361546
+                - 0.991151
+                - 0.993009
+                - 0.993009
+                - 0.997862182940346
+                - 0.99823
+                - 0.998602
+                - 0.998602
+                - 0.997883658588665
+                - 0.998247
+                - 0.998645
+                - 0.998618
+                - 0.989234853052088
+                - 0.991108
+                - 0.993153
+                - 0.993014
+                - 0.977987897893482
+                - 0.98189
+                - 0.986113
+                - 0.985827
+                - 0.953873809588552
+                - 0.962378
+                - 0.971415
+                - 0.970809
+                - 0.927243266086586
+                - 0.941245
+                - 0.955812
+                - 0.954845
+                - 0.864025853742296
+                - 0.892934
+                - 0.921423
+                - 0.919576
+          strategy: Linear
+          extrapolate: Clamp
+      min_soc: 0.35
+      max_soc: 0.9
+      save_interval: 1
+      state:
+        soc: 0.50003
+    fs:
+      pwr_out_max_watts: 2000000.0
+      pwr_ramp_lag_seconds: 1.1
+      energy_capacity_joules: 1601424000.0
+      specific_energy_joules_per_kilogram: ~
+      mass_kilograms: ~
+    fc:
+      thrml:
+        FuelConverterThermal:
+          heat_capacitance_joules_per_kelvin: 72132.17831078888
+          length_for_convection_meters: 0.5427107485587468
+          htc_to_amb_stop_watts_per_square_meter_kelvin: 60.7820169953251
+          conductance_from_comb_watts_per_kelvin: 2178.965385428629
+          max_frac_from_comb: 0.5
+          tstat_te_sto_kelvin: 358.15
+          tstat_te_delta_kelvin: 5.0
+          tstat_interp:
+            data:
+              grid:
+                - v: 1
+                  dim:
+                    - 2
+                  data:
+                    - 85.0
+                    - 90.0
+              values:
+                v: 1
+                dim:
+                  - 2
+                data:
+                  - 0.0
+                  - 1.0
+            strategy: Linear
+            extrapolate: Clamp
+          radiator_effectiveness: 168.06311964877182
+          fc_eff_model:
+            Exponential:
+              offset: 320.1873803210462
+              lag: 24.998774179607892
+              minimum: 0.1927168135089094
+      mass_kilograms: ~
+      specific_pwr_watts_per_kilogram: ~
+      pwr_out_max_watts: 112000.0
+      pwr_out_max_init_watts: 18360.655737704918
+      pwr_ramp_lag_seconds: 6.1
+      eff_interp_from_pwr_out:
+        data:
+          grid:
+            - v: 1
+              dim:
+                - 12
+              data:
+                - 0.0
+                - 0.005
+                - 0.015
+                - 0.04
+                - 0.06
+                - 0.1
+                - 0.14
+                - 0.2
+                - 0.4
+                - 0.6
+                - 0.8
+                - 1.0
+          values:
+            v: 1
+            dim:
+              - 12
+            data:
+              - 0.0900547945263104
+              - 0.10806575343157247
+              - 0.25215342467366914
+              - 0.3151917808420864
+              - 0.337705479473664
+              - 0.35121369865261054
+              - 0.3602191781052416
+              - 0.3602191781052416
+              - 0.3422082191999795
+              - 0.3332027397473485
+              - 0.32419726029471746
+              - 0.3151917808420864
+        strategy: Linear
+        extrapolate: Error
+      pwr_idle_fuel_watts: 0.0
+      save_interval: 1
+    em:
+      eff_interp_achieved:
+        data:
+          grid:
+            - v: 1
+              dim:
+                - 11
+              data:
+                - 0.0
+                - 0.02
+                - 0.04
+                - 0.06
+                - 0.08
+                - 0.1
+                - 0.2
+                - 0.4
+                - 0.6
+                - 0.8
+                - 1.0
+          values:
+            v: 1
+            dim:
+              - 11
+            data:
+              - 0.8210591042476243
+              - 0.844018240527504
+              - 0.8669773768073834
+              - 0.889936513087263
+              - 0.9014160812272026
+              - 0.9128956493671425
+              - 0.935854785647022
+              - 0.9473343537869616
+              - 0.9473343537869616
+              - 0.935854785647022
+              - 0.9243752175070823
+        strategy: Linear
+        extrapolate: Error
+      eff_interp_at_max_input:
+        data:
+          grid:
+            - v: 1
+              dim:
+                - 11
+              data:
+                - 0.0
+                - 0.023696170342835454
+                - 0.0461373053900192
+                - 0.06742053968755037
+                - 0.08874924872772037
+                - 0.10954154515833676
+                - 0.21370836914802546
+                - 0.42223740583354036
+                - 0.6333561087503105
+                - 0.8548334765921018
+                - 1.0818117806066543
+          values:
+            v: 1
+            dim:
+              - 11
+            data:
+              - 0.8210591042476243
+              - 0.844018240527504
+              - 0.8669773768073834
+              - 0.889936513087263
+              - 0.9014160812272026
+              - 0.9128956493671425
+              - 0.935854785647022
+              - 0.9473343537869616
+              - 0.9473343537869616
+              - 0.935854785647022
+              - 0.9243752175070823
+        strategy: Linear
+        extrapolate: Error
+      pwr_out_max_watts: 39000.0
+      specific_pwr_watts_per_kilogram: ~
+      mass_kilograms: ~
+      save_interval: 1
+    transmission:
+      mass_kilograms: ~
+      eff_interp: 0.98
+      save_interval: 1
+    pt_cntrl:
+      RGWDB:
+        speed_soc_disch_buffer_meters_per_second: 59.54927794431647
+        speed_soc_disch_buffer_coeff: 1.4370740568117162
+        speed_soc_fc_on_buffer_meters_per_second: 5.115023553506799
+        speed_soc_fc_on_buffer_coeff: 3.7567020585006974
+        speed_soc_regen_buffer_meters_per_second: 13.4112
+        speed_soc_regen_buffer_coeff: 1.0
+        fc_min_time_on_seconds: 12.722580080119371
+        speed_fc_forced_on_meters_per_second: 33.528
+        frac_pwr_demand_fc_forced_on: 0.4216108997716131
+        frac_of_most_eff_pwr_to_run_fc: 0.9464819140013936
+        temp_fc_forced_on_kelvin: 335.15
+        temp_fc_allowed_off_kelvin: 338.15
+    aux_cntrl: AuxOnResPriority
+    mass_kilograms: ~
+    sim_params:
+      res_per_fuel_lim: 0.005
+      soc_balance_iter_err: 5
+      balance_soc: true
+      save_soc_bal_iters: false
+chassis:
+  drag_coef: 0.24
+  frontal_area_square_meters: 2.48
+  wheel_rr_coef: 0.008801150703618045
+  wheel_inertia_kilogram_square_meters: 0.815
+  num_wheels: 4
+  wheel_radius_meters: 0.33645
+  tire_code: ~
+  cg_height_meters: 0.53
+  wheel_fric_coef: 0.7
+  drive_type: FWD
+  drive_axle_weight_frac: 0.59
+  wheel_base_meters: 2.83972
+  mass_kilograms: ~
+  glider_mass_kilograms: ~
+  cargo_mass_kilograms: ~
+cabin:
+  LumpedCabin:
+    cab_shell_htc_to_amb_watts_per_square_meter_kelvin: 10.111988385072632
+    cab_htc_to_amb_stop_watts_per_square_meter_kelvin: 153.22457193685642
+    heat_capacitance_joules_per_kelvin: 133887.55278894224
+    length_meters: 3.261651382829292
+    width_meters: 1.86
+hvac:
+  LumpedCabin:
+    te_set_kelvin: 295.15
+    te_deadband_kelvin: 0.5
+    p_watts_per_kelvin: 489.34499608760177
+    i: 36.77964270414921
+    pwr_i_max_watts: 10000.0
+    d: 5.0
+    pwr_thrml_max_watts: 15000.0
+    frac_of_ideal_cop: 0.0778419513178728
+    heat_source: FuelConverter
+    pwr_aux_for_hvac_max_watts: 8000.0
+mass_kilograms: 1508.195
+pwr_aux_base_watts: 500.0
+save_interval: 1

--- a/fastsim-core/src/vehicle/hev.rs
+++ b/fastsim-core/src/vehicle/hev.rs
@@ -25,6 +25,9 @@ pub struct HybridElectricVehicle {
     /// control strategy for distributing aux power demand between `fc` and `res`
     #[serde(default)]
     pub aux_cntrl: HEVAuxControls,
+    /// Alternator efficiency used to calculate aux mechanical power demand on fuel converter.
+    /// Only affects aux power loads supplied by the fuel converter.
+    pub alt_eff: si::Ratio,
     /// hybrid powertrain mass
     pub(crate) mass: Option<si::Mass>,
     #[serde(default)]
@@ -139,6 +142,7 @@ impl HybridElectricVehicle {
         transmission: Transmission,
         pt_cntrl: HEVPowertrainControls,
         aux_cntrl: HEVAuxControls,
+        alt_eff: si::Ratio,
         mass: Option<si::Mass>,
         sim_params: HEVSimulationParams,
     ) -> anyhow::Result<Self> {
@@ -150,6 +154,7 @@ impl HybridElectricVehicle {
             transmission,
             pt_cntrl,
             aux_cntrl,
+            alt_eff,
             mass,
             sim_params,
             soc_bal_iter_history: Default::default(),
@@ -297,7 +302,7 @@ impl Powertrain for Box<HybridElectricVehicle> {
 
         // set max propulsion powers
         self.fc
-            .set_curr_pwr_prop_max(pwr_aux_fc)
+            .set_curr_pwr_prop_max(pwr_aux_fc / self.alt_eff)
             .with_context(|| anyhow!(format_dbg!()))?;
         self.res
             .set_curr_pwr_prop_max(pwr_aux_res)
@@ -489,6 +494,7 @@ impl TryFrom<&fastsim_2::vehicle::RustVehicle> for HybridElectricVehicle {
             mass: None,
             sim_params: Default::default(),
             aux_cntrl: Default::default(),
+            alt_eff: f2veh.alt_eff * uc::R,
             soc_bal_iter_history: Default::default(),
             soc_bal_iters: Default::default(),
         };

--- a/fastsim-core/src/vehicle/hev.rs
+++ b/fastsim-core/src/vehicle/hev.rs
@@ -1,6 +1,11 @@
 use super::{vehicle_model::VehicleState, *};
 use crate::{prelude::ElectricMachineState, vehicle::common::*};
 
+// TODO: Remove this fallback at the next planned file-format breaking release.
+fn default_hev_alt_eff() -> si::Ratio {
+    1.0 * uc::R
+}
+
 #[serde_api]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, StateMethods, SetCumulative)]
 #[non_exhaustive]
@@ -27,6 +32,11 @@ pub struct HybridElectricVehicle {
     pub aux_cntrl: HEVAuxControls,
     /// Alternator efficiency used to calculate aux mechanical power demand on fuel converter.
     /// Only affects aux power loads supplied by the fuel converter.
+    //
+    // TEMP backward-compatibility behavior for legacy F3 files that omitted this field.
+    // Missing values default to 1.0 to preserve historical simulation behavior.
+    // TODO: Remove serde default on next format break.
+    #[serde(default = "default_hev_alt_eff")]
     pub alt_eff: si::Ratio,
     /// hybrid powertrain mass
     pub(crate) mass: Option<si::Mass>,
@@ -1524,5 +1534,19 @@ impl HEVStopStartControl {
             || format_dbg!(),
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::SerdeAPI;
+
+    #[test]
+    #[cfg(feature = "yaml")]
+    fn test_alt_eff_field_compatibility() {
+        use crate::vehicle::hev::default_hev_alt_eff;
+
+        let veh = crate::vehicle::Vehicle::from_yaml(include_str!("2021_Hyundai_Sonata_Hybrid_Blue.yaml"), false).unwrap();
+        assert_eq!(veh.hev().unwrap().alt_eff, default_hev_alt_eff())
     }
 }

--- a/fastsim-core/src/vehicle/vehicle_model.rs
+++ b/fastsim-core/src/vehicle/vehicle_model.rs
@@ -1418,6 +1418,7 @@ pub(crate) mod tests {
         )?;
         let pt_ctrl = HEVPowertrainControls::StopStart(Box::new(ctrl));
         let aux_ctrl = HEVAuxControls::AuxOnResPriority;
+        let alt_eff = 1.0 * uc::R;
         let sim_params = HEVSimulationParams::new(
             0.05 * uc::R, // res_per_fuel_lim
             5,            // soc_balance_iter_err
@@ -1432,6 +1433,7 @@ pub(crate) mod tests {
             tx,           // transmission
             pt_ctrl,      // pt_cntrl
             aux_ctrl,     // aux_cntrl
+            alt_eff,
             Option::None, // mass
             sim_params,   // sim_params
         )?;

--- a/fastsim-core/src/vehicle/vehicle_model.rs
+++ b/fastsim-core/src/vehicle/vehicle_model.rs
@@ -156,82 +156,12 @@ impl Vehicle {
 
     #[pyo3(name = "use_stop_start_controller")]
     fn use_stop_start_controller_py(&mut self) -> anyhow::Result<()> {
-        match &mut self.pt_type {
-            PowertrainType::ConventionalVehicle(veh) => {
-                match veh.pt_cntrl {
-                    ConvPowertrainControls::Normal => {
-                        let save_interval = veh.save_interval().unwrap_or(Option::None);
-                        veh.pt_cntrl =
-                            ConvPowertrainControls::StopStart(Box::new(ConvStopStartControl::new(
-                                Option::None, // fc_min_time_on
-                                Option::None, // temp_fc_forced_on
-                                Option::None, // temp_fc_allowed_off
-                                Option::None, // time_delay_after_stop_until_fc_can_turn_off
-                                save_interval,
-                            )?));
-                    }
-                    ConvPowertrainControls::StopStart(_) => (),
-                }
-            }
-            PowertrainType::HybridElectricVehicle(veh) => match veh.pt_cntrl {
-                HEVPowertrainControls::RGWDB(_) => {
-                    let save_interval = veh.save_interval().unwrap_or(Option::None);
-                    veh.pt_cntrl =
-                        HEVPowertrainControls::StopStart(Box::new(HEVStopStartControl::new(
-                            Option::None, // fc_min_time_on
-                            Option::None, // soc_fc_forced_on
-                            Option::None, // frac_of_most_eff_pwr_to_run_fc
-                            Option::None, // temp_fc_forced_on
-                            Option::None, // temp_fc_allowed_off
-                            Option::None, // time_delay_after_stop_until_fc_can_turn_off
-                            Option::None, // em_can_regen
-                            save_interval,
-                        )?));
-                }
-                HEVPowertrainControls::StopStart(_) => (),
-            },
-            _ => (),
-        }
-        Ok(())
+        self.use_stop_start_controller()
     }
 
     #[pyo3(name = "use_normal_controller")]
     fn use_normal_controller_py(&mut self) -> anyhow::Result<()> {
-        let save_interval = self.save_interval().unwrap_or(Option::None);
-        match &mut self.pt_type {
-            PowertrainType::ConventionalVehicle(conv) => match &conv.pt_cntrl {
-                ConvPowertrainControls::StopStart(_) => {
-                    conv.pt_cntrl = ConvPowertrainControls::Normal;
-                }
-                ConvPowertrainControls::Normal => (),
-            },
-            PowertrainType::HybridElectricVehicle(hev) => {
-                match &hev.pt_cntrl {
-                    HEVPowertrainControls::StopStart(_) => {
-                        hev.pt_cntrl = HEVPowertrainControls::RGWDB(Box::new(
-                            RESGreedyWithDynamicBuffers::new(
-                                Option::None, // speed_soc_disch_buffer
-                                Option::None, // speed_soc_disch_buffer_coeff
-                                Option::None, // speed_soc_fc_on_buffer
-                                Option::None, // speed_soc_fc_on_buffer_coeff
-                                Option::None, // speed_soc_regen_buffer
-                                Option::None, // speed_soc_regen_buffer_coeff
-                                Option::None, // fc_min_time_on
-                                Option::None, // speed_fc_forced_on
-                                Option::None, // frac_pwr_demand_fc_forced_on
-                                Option::None, // frac_of_most_eff_pwr_to_run_fc
-                                Option::None, // temp_fc_forced_on
-                                Option::None, // temp_fc_allowed_off
-                                save_interval,
-                            )?,
-                        ))
-                    }
-                    HEVPowertrainControls::RGWDB(_) => (),
-                }
-            }
-            _ => (),
-        }
-        Ok(())
+        self.use_normal_controller()
     }
 
     #[pyo3(name = "set_dfco_params")]
@@ -241,18 +171,7 @@ impl Vehicle {
         min_dfco_speed_m_per_s: f64,
         max_accel_for_dfco_m_per_s2: f64,
     ) -> anyhow::Result<()> {
-        let min_dfco_speed_m_per_s = min_dfco_speed_m_per_s.max(0.0);
-        let max_accel_for_dfco_m_per_s2 = max_accel_for_dfco_m_per_s2.min(0.0);
-        match &mut self.pt_type {
-            PowertrainType::ConventionalVehicle(conv) => {
-                conv.dfco_cntrl.dfco_enabled = enabled;
-                conv.dfco_cntrl.minimum_dfco_speed = min_dfco_speed_m_per_s * uc::MPS;
-                conv.dfco_cntrl.minimum_dfco_deceleration = max_accel_for_dfco_m_per_s2 * uc::MPS2;
-                conv.dfco_cntrl.save_interval = self.save_interval;
-            }
-            _ => (),
-        }
-        Ok(())
+        self.set_dfco_params(enabled, min_dfco_speed_m_per_s, max_accel_for_dfco_m_per_s2)
     }
 }
 
@@ -287,6 +206,102 @@ impl Vehicle {
         };
         veh.init()?;
         Ok(veh)
+    }
+
+    pub fn use_stop_start_controller(&mut self) -> anyhow::Result<()> {
+        match &mut self.pt_type {
+            PowertrainType::ConventionalVehicle(veh) => match veh.pt_cntrl {
+                ConvPowertrainControls::Normal => {
+                    let save_interval = veh.save_interval().unwrap_or(Option::None);
+                    veh.pt_cntrl = ConvPowertrainControls::StopStart(Box::new(
+                        ConvStopStartControl::new(
+                            Option::None, // fc_min_time_on
+                            Option::None, // temp_fc_forced_on
+                            Option::None, // temp_fc_allowed_off
+                            Option::None, // time_delay_after_stop_until_fc_can_turn_off
+                            save_interval,
+                        )?,
+                    ));
+                }
+                ConvPowertrainControls::StopStart(_) => (),
+            },
+            PowertrainType::HybridElectricVehicle(veh) => match veh.pt_cntrl {
+                HEVPowertrainControls::RGWDB(_) => {
+                    let save_interval = veh.save_interval().unwrap_or(Option::None);
+                    veh.pt_cntrl = HEVPowertrainControls::StopStart(Box::new(
+                        HEVStopStartControl::new(
+                            Option::None, // fc_min_time_on
+                            Option::None, // soc_fc_forced_on
+                            Option::None, // frac_of_most_eff_pwr_to_run_fc
+                            Option::None, // temp_fc_forced_on
+                            Option::None, // temp_fc_allowed_off
+                            Option::None, // time_delay_after_stop_until_fc_can_turn_off
+                            Option::None, // em_can_regen
+                            save_interval,
+                        )?,
+                    ));
+                }
+                HEVPowertrainControls::StopStart(_) => (),
+            },
+            _ => (),
+        }
+        Ok(())
+    }
+
+    pub fn use_normal_controller(&mut self) -> anyhow::Result<()> {
+        let save_interval = self.save_interval().unwrap_or(Option::None);
+        match &mut self.pt_type {
+            PowertrainType::ConventionalVehicle(conv) => match &conv.pt_cntrl {
+                ConvPowertrainControls::StopStart(_) => {
+                    conv.pt_cntrl = ConvPowertrainControls::Normal;
+                }
+                ConvPowertrainControls::Normal => (),
+            },
+            PowertrainType::HybridElectricVehicle(hev) => match &hev.pt_cntrl {
+                HEVPowertrainControls::StopStart(_) => {
+                    hev.pt_cntrl = HEVPowertrainControls::RGWDB(Box::new(
+                        RESGreedyWithDynamicBuffers::new(
+                            Option::None, // speed_soc_disch_buffer
+                            Option::None, // speed_soc_disch_buffer_coeff
+                            Option::None, // speed_soc_fc_on_buffer
+                            Option::None, // speed_soc_fc_on_buffer_coeff
+                            Option::None, // speed_soc_regen_buffer
+                            Option::None, // speed_soc_regen_buffer_coeff
+                            Option::None, // fc_min_time_on
+                            Option::None, // speed_fc_forced_on
+                            Option::None, // frac_pwr_demand_fc_forced_on
+                            Option::None, // frac_of_most_eff_pwr_to_run_fc
+                            Option::None, // temp_fc_forced_on
+                            Option::None, // temp_fc_allowed_off
+                            save_interval,
+                        )?,
+                    ))
+                }
+                HEVPowertrainControls::RGWDB(_) => (),
+            },
+            _ => (),
+        }
+        Ok(())
+    }
+
+    pub fn set_dfco_params(
+        &mut self,
+        enabled: bool,
+        min_dfco_speed_m_per_s: f64,
+        max_accel_for_dfco_m_per_s2: f64,
+    ) -> anyhow::Result<()> {
+        let min_dfco_speed_m_per_s = min_dfco_speed_m_per_s.max(0.0);
+        let max_accel_for_dfco_m_per_s2 = max_accel_for_dfco_m_per_s2.min(0.0);
+        match &mut self.pt_type {
+            PowertrainType::ConventionalVehicle(conv) => {
+                conv.dfco_cntrl.dfco_enabled = enabled;
+                conv.dfco_cntrl.minimum_dfco_speed = min_dfco_speed_m_per_s * uc::MPS;
+                conv.dfco_cntrl.minimum_dfco_deceleration = max_accel_for_dfco_m_per_s2 * uc::MPS2;
+                conv.dfco_cntrl.save_interval = self.save_interval;
+            }
+            _ => (),
+        }
+        Ok(())
     }
 }
 
@@ -1615,7 +1630,7 @@ pub(crate) mod tests {
         let veh_result = make_conv_pacifica(false, false);
         assert!(veh_result.is_ok());
         let mut veh = veh_result.unwrap();
-        let use_result = veh.use_stop_start_controller_py();
+        let use_result = veh.use_stop_start_controller();
         assert!(use_result.is_ok());
         match &veh.pt_type {
             PowertrainType::ConventionalVehicle(conv) => match conv.pt_cntrl {
@@ -1628,7 +1643,7 @@ pub(crate) mod tests {
                 assert!(false, "Unexpected powertrain type");
             }
         }
-        let normal_result = veh.use_normal_controller_py();
+        let normal_result = veh.use_normal_controller();
         assert!(normal_result.is_ok());
         match &veh.pt_type {
             PowertrainType::ConventionalVehicle(conv) => match conv.pt_cntrl {
@@ -1648,7 +1663,7 @@ pub(crate) mod tests {
         let veh_result = make_microhybrid_pacifica();
         assert!(veh_result.is_ok());
         let mut veh = veh_result.unwrap();
-        let use_result = veh.use_normal_controller_py();
+        let use_result = veh.use_normal_controller();
         assert!(use_result.is_ok());
         match &veh.pt_type {
             PowertrainType::HybridElectricVehicle(hev) => match &hev.pt_cntrl {
@@ -1661,7 +1676,7 @@ pub(crate) mod tests {
                 assert!(false, "Unexpected powertrain type");
             }
         }
-        let use_ss_result = veh.use_stop_start_controller_py();
+        let use_ss_result = veh.use_stop_start_controller();
         assert!(use_ss_result.is_ok());
         match &veh.pt_type {
             PowertrainType::HybridElectricVehicle(hev) => match &hev.pt_cntrl {


### PR DESCRIPTION
This PR fixes a small bug I found where HEVs/PHEVs did not account for alternator efficiency in aux power loads coming supplied by the fuel converter. Aux loads supplied by the RES are assumed to be all electric as is our assumption for BEVs so there is no alternator to account for there.

In fact, we did not even have an alternator efficiency in the HybridElectricVehicle at all, so this PR adds that and makes a default of 100% to maintain compatibility with existing vehicle files (that would otherwise have a missing field and fail to deserialize). There is also a test to make sure this works as expected. Maybe we can add a logging event letting the user know the default value of 100% was used? I anticipate getting rid of this serde default as soon as we switch to a break in the vehicle file format (next major version?)

A hiccup I predict with this change: if we want to model fuel cells in FASTSim 3 as HEVs (but have a different powertrain type, just like we do for PHEVs), then having an alternator efficiency in the HybridElectricVehicle doesn't exactly make sense, as they have no alternator. We can enforce this field to be 100% but I really don't like the idea of having fields that don't apply - that feels like a FASTSim-2-ism.
- We could just make the alt_eff for HEVs `Option<si::Ratio>` instead, and make None unwrap to 100%
- Relevant #270

I also dont like how we model alternator as a ratio rather than an interpolator. Could we support alternators that have varying efficiency based on power load? FC temperature as a surrogate?