### PR TITLE
Skip serializing history if it is empty

### DIFF
--- a/cal_and_val/f3-vehicles/2010 Mazda 3 i-Stop.yaml
+++ b/cal_and_val/f3-vehicles/2010 Mazda 3 i-Stop.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2012 Ford Focus.yaml
+++ b/cal_and_val/f3-vehicles/2012 Ford Focus.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2012 Ford Fusion.yaml
+++ b/cal_and_val/f3-vehicles/2012 Ford Fusion.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 AUDI A3 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 AUDI A3 4cyl 2WD.yaml
@@ -14,7 +14,7 @@ pt_type:
       thrml: None
       mass_kilograms: ~
       specific_pwr_watts_per_kilogram: ~
-      pwr_out_max_watts: 126000.0
+      pwr_out_max_watts: 112000.0
       pwr_out_max_init_watts: 18666.666666666668
       pwr_ramp_lag_seconds: 6.0
       eff_interp_from_pwr_out:
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -136,9 +107,9 @@ chassis:
   wheel_radius_meters: 0.336
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.8
+  wheel_fric_coef: 0.7
   drive_type: FWD
-  drive_axle_weight_frac: 0.61
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 BMW 328d 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 BMW 328d 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -136,9 +107,9 @@ chassis:
   wheel_radius_meters: 0.336
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.8
-  drive_type: RWD
-  drive_axle_weight_frac: 0.61
+  wheel_fric_coef: 0.7
+  drive_type: FWD
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 BMW i3 REx PHEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 BMW i3 REx PHEV.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Malibu 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Malibu 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Spark EV.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Spark EV.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 CHEVROLET Volt.yaml
+++ b/cal_and_val/f3-vehicles/2016 CHEVROLET Volt.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 FORD C-MAX (PHEV).yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD C-MAX (PHEV).yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 FORD C-MAX HEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD C-MAX HEV.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.95
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 FORD Escape 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD Escape 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 FORD Explorer 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 FORD Explorer 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 HYUNDAI Elantra 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 HYUNDAI Elantra 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 HYUNDAI Sonata PHEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 HYUNDAI Sonata PHEV.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 Hyundai Tucson Fuel Cell.yaml
+++ b/cal_and_val/f3-vehicles/2016 Hyundai Tucson Fuel Cell.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 1000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 KIA Optima Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2016 KIA Optima Hybrid.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.95
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 Leaf 24 kWh.yaml
+++ b/cal_and_val/f3-vehicles/2016 Leaf 24 kWh.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 MITSUBISHI i-MiEV.yaml
+++ b/cal_and_val/f3-vehicles/2016 MITSUBISHI i-MiEV.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 Nissan Leaf 30 kWh.yaml
+++ b/cal_and_val/f3-vehicles/2016 Nissan Leaf 30 kWh.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 TESLA Model S60 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TESLA Model S60 2WD.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,7 +156,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.336
   tire_code: ~
-  cg_height_meters: -0.445
+  cg_height_meters: 0.445
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Camry 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Camry 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Corolla 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Corolla 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 TOYOTA Highlander Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2016 TOYOTA Highlander Hybrid.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.95
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2016 Toyota Prius Two FWD.yaml
+++ b/cal_and_val/f3-vehicles/2016 Toyota Prius Two FWD.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2017 CHEVROLET Bolt.yaml
+++ b/cal_and_val/f3-vehicles/2017 CHEVROLET Bolt.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2017 Maruti Dzire VDI.yaml
+++ b/cal_and_val/f3-vehicles/2017 Maruti Dzire VDI.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2017 Prius Prime.yaml
+++ b/cal_and_val/f3-vehicles/2017 Prius Prime.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2017 Toyota Highlander 3.5 L.yaml
+++ b/cal_and_val/f3-vehicles/2017 Toyota Highlander 3.5 L.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2020 Chevrolet Colorado 2WD Diesel.yaml
+++ b/cal_and_val/f3-vehicles/2020 Chevrolet Colorado 2WD Diesel.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -137,7 +108,7 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.7
-  drive_type: RWD
+  drive_type: FWD
   drive_axle_weight_frac: 0.61
   wheel_base_meters: 3.26
   mass_kilograms: ~
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2020 Hero Splendor+ 100cc.yaml
+++ b/cal_and_val/f3-vehicles/2020 Hero Splendor+ 100cc.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2020 VW Golf 1.5TSI.yaml
+++ b/cal_and_val/f3-vehicles/2020 VW Golf 1.5TSI.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2020 VW Golf 2.0TDI.yaml
+++ b/cal_and_val/f3-vehicles/2020 VW Golf 2.0TDI.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2021 BMW iX xDrive40.yaml
+++ b/cal_and_val/f3-vehicles/2021 BMW iX xDrive40.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,7 +156,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.395
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
   drive_type: RWD
   drive_axle_weight_frac: 0.61
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2021 Cupra Born.yaml
+++ b/cal_and_val/f3-vehicles/2021 Cupra Born.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,7 +156,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.3488
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
   drive_type: RWD
   drive_axle_weight_frac: 0.61
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2021 Fiat Panda Mild Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/2021 Fiat Panda Mild Hybrid.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2021 Honda N-Box G.yaml
+++ b/cal_and_val/f3-vehicles/2021 Honda N-Box G.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2021 Peugot 3008.yaml
+++ b/cal_and_val/f3-vehicles/2021 Peugot 3008.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Ford F-150 Lightning 4WD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Ford F-150 Lightning 4WD.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,10 +156,10 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.4169
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: RWD
+  drive_axle_weight_frac: 0.59
   wheel_base_meters: 2.6
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 MINI Cooper SE Hardtop 2 door.yaml
+++ b/cal_and_val/f3-vehicles/2022 MINI Cooper SE Hardtop 2 door.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Renault Megane E-Tech.yaml
+++ b/cal_and_val/f3-vehicles/2022 Renault Megane E-Tech.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Renault Zoe ZE50 R135.yaml
+++ b/cal_and_val/f3-vehicles/2022 Renault Zoe ZE50 R135.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.92
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Tesla Model 3 RWD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Tesla Model 3 RWD.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,7 +156,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.33435
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Tesla Model Y RWD.yaml
+++ b/cal_and_val/f3-vehicles/2022 Tesla Model Y RWD.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -207,7 +156,7 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.36295
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.7
   drive_type: RWD
   drive_axle_weight_frac: 0.59
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Toyota RAV4 Hybrid LE.yaml
+++ b/cal_and_val/f3-vehicles/2022 Toyota RAV4 Hybrid LE.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 1000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -213,7 +177,7 @@ pt_type:
               - 0.93
         strategy: Linear
         extrapolate: Error
-      pwr_out_max_watts: 25000.0
+      pwr_out_max_watts: 128000.0
       specific_pwr_watts_per_kilogram: ~
       mass_kilograms: ~
       save_interval: 1
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.97
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -333,10 +257,10 @@ chassis:
   num_wheels: 4
   wheel_radius_meters: 0.36215
   tire_code: ~
-  cg_height_meters: -0.53
+  cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: RWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.68986
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Toyota Yaris Hybrid Mid.yaml
+++ b/cal_and_val/f3-vehicles/2022 Toyota Yaris Hybrid Mid.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.97
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2022 Volvo XC40 Recharge twin.yaml
+++ b/cal_and_val/f3-vehicles/2022 Volvo XC40 Recharge twin.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -209,8 +158,8 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.702
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2023 Mitsubishi Pajero Sport.yaml
+++ b/cal_and_val/f3-vehicles/2023 Mitsubishi Pajero Sport.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2023 Polestar 2 Long range Dual motor.yaml
+++ b/cal_and_val/f3-vehicles/2023 Polestar 2 Long range Dual motor.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -209,8 +158,8 @@ chassis:
   tire_code: ~
   cg_height_meters: 0.53
   wheel_fric_coef: 0.8
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.73558
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2023 Volvo C40 Recharge.yaml
+++ b/cal_and_val/f3-vehicles/2023 Volvo C40 Recharge.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -208,9 +157,9 @@ chassis:
   wheel_radius_meters: 0.356
   tire_code: ~
   cg_height_meters: 0.53
-  wheel_fric_coef: 0.7
-  drive_type: AWD
-  drive_axle_weight_frac: 1.0
+  wheel_fric_coef: 0.8
+  drive_type: FWD
+  drive_axle_weight_frac: 0.61
   wheel_base_meters: 2.702
   mass_kilograms: ~
   glider_mass_kilograms: ~
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2024 BYD Dolphin Active.yaml
+++ b/cal_and_val/f3-vehicles/2024 BYD Dolphin Active.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2024 Toyota Vios 1.5 G.yaml
+++ b/cal_and_val/f3-vehicles/2024 Toyota Vios 1.5 G.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2024 VinFast VF e34.yaml
+++ b/cal_and_val/f3-vehicles/2024 VinFast VF e34.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/2024 Volkswagen Polo 1.0 MPI.yaml
+++ b/cal_and_val/f3-vehicles/2024 Volkswagen Polo 1.0 MPI.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/BYD ATTO 3.yaml
+++ b/cal_and_val/f3-vehicles/BYD ATTO 3.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.95
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Bajaj Boxer 150.yaml
+++ b/cal_and_val/f3-vehicles/Bajaj Boxer 150.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Class 4 Truck (Isuzu NPR HD).yaml
+++ b/cal_and_val/f3-vehicles/Class 4 Truck (Isuzu NPR HD).yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Line Haul Conv.yaml
+++ b/cal_and_val/f3-vehicles/Line Haul Conv.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Maruti Swift 4cyl 2WD.yaml
+++ b/cal_and_val/f3-vehicles/Maruti Swift 4cyl 2WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Nissan Navara.yaml
+++ b/cal_and_val/f3-vehicles/Nissan Navara.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Regional Delivery Class 8 Truck.yaml
+++ b/cal_and_val/f3-vehicles/Regional Delivery Class 8 Truck.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Renault Clio IV diesel.yaml
+++ b/cal_and_val/f3-vehicles/Renault Clio IV diesel.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Renault Megane 1.5 dCi Authentique.yaml
+++ b/cal_and_val/f3-vehicles/Renault Megane 1.5 dCi Authentique.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Toyota Corolla Cross Hybrid.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Corolla Cross Hybrid.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.97
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Toyota Etios Liva diesel.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Etios Liva diesel.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Toyota Hilux Double Cab 4WD.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Hilux Double Cab 4WD.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/cal_and_val/f3-vehicles/Toyota Mirai.yaml
+++ b/cal_and_val/f3-vehicles/Toyota Mirai.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 1000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/fastsim-core/resources/vehicles/2012_Ford_Fusion.yaml
+++ b/fastsim-core/resources/vehicles/2012_Ford_Fusion.yaml
@@ -71,21 +71,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     transmission:
       mass_kilograms: ~
@@ -101,17 +86,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl: Normal
     dfco_cntrl:
@@ -122,9 +96,6 @@ pt_type:
       state:
         i: 0
         vehicle_dynamics_prevent_dfco: false
-      history:
-        i: []
-        vehicle_dynamics_prevent_dfco: []
     mass_kilograms: ~
     alt_eff: 1.0
 chassis:
@@ -152,6 +123,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -178,33 +150,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/fastsim-core/resources/vehicles/2016_TOYOTA_Prius_Two.yaml
+++ b/fastsim-core/resources/vehicles/2016_TOYOTA_Prius_Two.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     fs:
       pwr_out_max_watts: 2000000.0
@@ -124,21 +103,6 @@ pt_type:
         energy_loss_joules: 0.0
         fc_on: false
         time_on_seconds: 0.0
-      history:
-        i: []
-        pwr_out_max_watts: []
-        pwr_prop_max_watts: []
-        eff: []
-        pwr_prop_watts: []
-        energy_prop_joules: []
-        pwr_aux_watts: []
-        energy_aux_joules: []
-        pwr_fuel_watts: []
-        energy_fuel_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
-        fc_on: []
-        time_on_seconds: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -236,25 +200,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.98
@@ -269,17 +214,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     pt_cntrl:
       RGWDB:
@@ -306,16 +240,6 @@ pt_type:
           aux_power_demand: false
           charging_for_low_soc: false
           soc_fc_on_buffer: 0.0
-        history:
-          i: []
-          fc_temperature_too_low: []
-          vehicle_speed_too_high: []
-          on_time_too_short: []
-          propulsion_power_demand: []
-          propulsion_power_demand_soft: []
-          aux_power_demand: []
-          charging_for_low_soc: []
-          soc_fc_on_buffer: []
     aux_cntrl: AuxOnResPriority
     mass_kilograms: ~
     sim_params:
@@ -350,6 +274,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -376,33 +301,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/fastsim-core/resources/vehicles/2022_Renault_Zoe_ZE50_R135.yaml
+++ b/fastsim-core/resources/vehicles/2022_Renault_Zoe_ZE50_R135.yaml
@@ -35,27 +35,6 @@ pt_type:
         energy_aux_joules: 0.0
         energy_loss_joules: 0.0
         energy_out_chemical_joules: 0.0
-      history:
-        pwr_prop_max_watts: []
-        pwr_regen_max_watts: []
-        pwr_disch_max_watts: []
-        pwr_charge_max_watts: []
-        i: []
-        soc: []
-        soc_regen_buffer: []
-        soc_disch_buffer: []
-        eff: []
-        soh: []
-        pwr_out_electrical_watts: []
-        pwr_out_prop_watts: []
-        pwr_aux_watts: []
-        pwr_loss_watts: []
-        pwr_out_chemical_watts: []
-        energy_out_electrical_joules: []
-        energy_out_prop_joules: []
-        energy_aux_joules: []
-        energy_loss_joules: []
-        energy_out_chemical_joules: []
       save_interval: 1
     em:
       eff_interp_achieved:
@@ -153,25 +132,6 @@ pt_type:
         energy_elec_dyn_brake_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        eff: []
-        pwr_mech_fwd_out_max_watts: []
-        eff_fwd_at_max_input: []
-        pwr_mech_regen_max_watts: []
-        eff_at_max_regen: []
-        pwr_out_req_watts: []
-        energy_out_req_joules: []
-        pwr_elec_prop_in_watts: []
-        energy_elec_prop_in_joules: []
-        pwr_mech_prop_out_watts: []
-        energy_mech_prop_out_joules: []
-        pwr_mech_dyn_brake_watts: []
-        energy_mech_dyn_brake_joules: []
-        pwr_elec_dyn_brake_watts: []
-        energy_elec_dyn_brake_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
     transmission:
       mass_kilograms: ~
       eff_interp: 0.92
@@ -186,17 +146,6 @@ pt_type:
         energy_in_joules: 0.0
         pwr_loss_watts: 0.0
         energy_loss_joules: 0.0
-      history:
-        i: []
-        pwr_out_fwd_max_watts: []
-        pwr_out_regen_max_watts: []
-        eff: []
-        pwr_out_watts: []
-        energy_out_joules: []
-        pwr_in_watts: []
-        energy_in_joules: []
-        pwr_loss_watts: []
-        energy_loss_joules: []
       save_interval: 1
     mass_kilograms: ~
 chassis:
@@ -224,6 +173,7 @@ state:
   i: 0
   time_seconds: 0.0
   pwr_prop_fwd_max_watts: 0.0
+  speed_trac_fwd_max_meters_per_second: 0.0
   pwr_prop_bwd_max_watts: 0.0
   pwr_tractive_watts: 0.0
   pwr_tractive_for_cyc_watts: 0.0
@@ -250,33 +200,3 @@ state:
   elev_curr_meters: 0.0
   air_density_kilograms_per_cubic_meter: 0.0
   mass_kilograms: .nan
-history:
-  i: []
-  time_seconds: []
-  pwr_prop_fwd_max_watts: []
-  pwr_prop_bwd_max_watts: []
-  pwr_tractive_watts: []
-  pwr_tractive_for_cyc_watts: []
-  energy_tractive_joules: []
-  pwr_aux_watts: []
-  energy_aux_joules: []
-  pwr_drag_watts: []
-  energy_drag_joules: []
-  pwr_accel_watts: []
-  energy_accel_joules: []
-  pwr_ascent_watts: []
-  energy_ascent_joules: []
-  pwr_rr_watts: []
-  energy_rr_joules: []
-  pwr_whl_inertia_watts: []
-  energy_whl_inertia_joules: []
-  pwr_brake_watts: []
-  energy_brake_joules: []
-  cyc_met: []
-  cyc_met_overall: []
-  speed_ach_meters_per_second: []
-  dist_meters: []
-  grade_curr: []
-  elev_curr_meters: []
-  air_density_kilograms_per_cubic_meter: []
-  mass_kilograms: []

--- a/fastsim-core/src/vehicle/cabin.rs
+++ b/fastsim-core/src/vehicle/cabin.rs
@@ -169,7 +169,7 @@ pub struct LumpedCabin {
     pub width: si::Length,
     #[serde(default)]
     pub state: LumpedCabinState,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "LumpedCabinStateHistoryVec::is_empty")]
     pub history: LumpedCabinStateHistoryVec,
     /// Time step interval at which history is saved
     pub save_interval: Option<usize>,

--- a/fastsim-core/src/vehicle/conv.rs
+++ b/fastsim-core/src/vehicle/conv.rs
@@ -26,6 +26,7 @@ pub struct DfcoControls {
     #[serde(default)]
     pub state: DfcoState,
     /// history of current state
+    #[serde(default, skip_serializing_if = "DfcoStateHistoryVec::is_empty")]
     pub history: DfcoStateHistoryVec,
 }
 
@@ -585,6 +586,10 @@ pub struct ConvStopStartControl {
     #[serde(default)]
     pub state: ConvStopStartState,
     /// history of current state
+    #[serde(
+        default,
+        skip_serializing_if = "ConvStopStartStateHistoryVec::is_empty"
+    )]
     pub history: ConvStopStartStateHistoryVec,
 }
 

--- a/fastsim-core/src/vehicle/hev.rs
+++ b/fastsim-core/src/vehicle/hev.rs
@@ -946,8 +946,8 @@ pub struct RESGreedyWithDynamicBuffers {
     /// current state of control variables
     #[serde(default)]
     pub state: RGWDBState,
-    #[serde(default)]
     /// history of current state
+    #[serde(default, skip_serializing_if = "RGWDBStateHistoryVec::is_empty")]
     pub history: RGWDBStateHistoryVec,
 }
 
@@ -1337,6 +1337,7 @@ pub struct HEVStopStartControl {
     #[serde(default)]
     pub state: StopStartState,
     /// history of current state
+    #[serde(default, skip_serializing_if = "StopStartStateHistoryVec::is_empty")]
     pub history: StopStartStateHistoryVec,
 }
 

--- a/fastsim-core/src/vehicle/hvac/hvac_sys_for_lumped_cabin.rs
+++ b/fastsim-core/src/vehicle/hvac/hvac_sys_for_lumped_cabin.rs
@@ -33,7 +33,10 @@ pub struct HVACSystemForLumpedCabin {
     /// coefficient of performance of vapor compression cycle
     #[serde(default)]
     pub state: HVACSystemForLumpedCabinState,
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "HVACSystemForLumpedCabinStateHistoryVec::is_empty"
+    )]
     pub history: HVACSystemForLumpedCabinStateHistoryVec,
     pub save_interval: Option<usize>,
 }

--- a/fastsim-core/src/vehicle/hvac/hvac_sys_for_lumped_cabin_and_res.rs
+++ b/fastsim-core/src/vehicle/hvac/hvac_sys_for_lumped_cabin_and_res.rs
@@ -55,7 +55,10 @@ pub struct HVACSystemForLumpedCabinAndRES {
     /// coefficient of performance of vapor compression cycle
     #[serde(default)]
     pub state: HVACSystemForLumpedCabinAndRESState,
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "HVACSystemForLumpedCabinAndRESStateHistoryVec::is_empty"
+    )]
     pub history: HVACSystemForLumpedCabinAndRESStateHistoryVec,
     pub save_interval: Option<usize>,
 }

--- a/fastsim-core/src/vehicle/powertrain/electric_machine.rs
+++ b/fastsim-core/src/vehicle/powertrain/electric_machine.rs
@@ -39,7 +39,10 @@ pub struct ElectricMachine {
     #[serde(default)]
     pub state: ElectricMachineState,
     /// Custom vector of [Self::state]
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "ElectricMachineStateHistoryVec::is_empty"
+    )]
     pub history: ElectricMachineStateHistoryVec,
 }
 
@@ -562,7 +565,11 @@ impl Mass for ElectricMachine {
                 )
             }
         };
-        ensure!(self.mass > Some(0.0 * uc::KG), "{} mass must be positive", stringify!(ElectricMachine));
+        ensure!(
+            self.mass > Some(0.0 * uc::KG),
+            "{} mass must be positive",
+            stringify!(ElectricMachine)
+        );
         Ok(())
     }
 

--- a/fastsim-core/src/vehicle/powertrain/fuel_converter.rs
+++ b/fastsim-core/src/vehicle/powertrain/fuel_converter.rs
@@ -41,7 +41,10 @@ pub struct FuelConverter {
     #[serde(default)]
     pub state: FuelConverterState,
     /// Custom vector of [Self::state]
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "FuelConverterStateHistoryVec::is_empty"
+    )]
     pub history: FuelConverterStateHistoryVec,
     /// time step interval between saves. 1 is a good option. If None, no saving occurs.
     pub save_interval: Option<usize>,
@@ -817,7 +820,10 @@ pub struct FuelConverterThermal {
     #[serde(default)]
     pub state: FuelConverterThermalState,
     /// Custom vector of [Self::state]
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "FuelConverterThermalStateHistoryVec::is_empty"
+    )]
     pub history: FuelConverterThermalStateHistoryVec,
     pub save_interval: Option<usize>,
 }

--- a/fastsim-core/src/vehicle/powertrain/reversible_energy_storage.rs
+++ b/fastsim-core/src/vehicle/powertrain/reversible_energy_storage.rs
@@ -40,7 +40,10 @@ pub struct ReversibleEnergyStorage {
     #[serde(default)]
     pub state: ReversibleEnergyStorageState,
     /// Custom vector of [Self::state]
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "ReversibleEnergyStorageStateHistoryVec::is_empty"
+    )]
     pub history: ReversibleEnergyStorageStateHistoryVec,
     /// Time step interval at which history is saved
     pub save_interval: Option<usize>,
@@ -792,7 +795,7 @@ impl Mass for ReversibleEnergyStorage {
                     }
                 }
                 Some(new_mass)
-            },
+            }
             (Some(new_mass), None) => Some(new_mass),
             (None, Some(dm)) => Some(dm),
             (None, None) => bail!(
@@ -1146,7 +1149,10 @@ pub struct RESLumpedThermal {
     #[serde(default)]
     pub state: RESLumpedThermalState,
     /// history of state
-    #[serde(default)]
+    #[serde(
+        default,
+        skip_serializing_if = "RESLumpedThermalStateHistoryVec::is_empty"
+    )]
     pub history: RESLumpedThermalStateHistoryVec,
     pub save_interval: Option<usize>,
 }

--- a/fastsim-core/src/vehicle/powertrain/transmission.rs
+++ b/fastsim-core/src/vehicle/powertrain/transmission.rs
@@ -16,7 +16,7 @@ pub struct Transmission {
     #[serde(default)]
     pub state: TransmissionState,
     /// Custom vector of [Self::state]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "TransmissionStateHistoryVec::is_empty")]
     pub history: TransmissionStateHistoryVec,
     /// time step interval between saves. 1 is a good option. If None, no saving occurs.
     pub save_interval: Option<usize>,
@@ -176,7 +176,11 @@ impl Mass for Transmission {
     ) -> anyhow::Result<()> {
         match new_mass {
             Some(_) => {
-                ensure!(new_mass > Some(0.0 * uc::KG), "{} mass must be positive", stringify!(Transmission));
+                ensure!(
+                    new_mass > Some(0.0 * uc::KG),
+                    "{} mass must be positive",
+                    stringify!(Transmission)
+                );
                 self.mass = new_mass;
             }
             None => {

--- a/fastsim-core/src/vehicle/vehicle_model.rs
+++ b/fastsim-core/src/vehicle/vehicle_model.rs
@@ -63,7 +63,7 @@ pub struct Vehicle {
     #[serde(default)]
     pub state: VehicleState,
     /// Vector-like history of [Self::state]
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "VehicleStateHistoryVec::is_empty")]
     pub history: VehicleStateHistoryVec,
 }
 
@@ -626,17 +626,15 @@ impl Vehicle {
         //   AWD/4WD: both axles drive, weight transfer doesn't reduce total drive grip
         let cg_height_abs = self.chassis.cg_height.abs();
         let weight_transfer_sign: f64 = match self.chassis.drive_type {
-            chassis::DriveTypes::FWD => 1.0,    // weight shifts away from front drive axle → reduces traction
-            chassis::DriveTypes::RWD => -1.0,   // weight shifts toward rear drive axle → increases traction
-            chassis::DriveTypes::AWD
-            | chassis::DriveTypes::FourWD => 0.0, // net zero effect on total drive traction
+            chassis::DriveTypes::FWD => 1.0, // weight shifts away from front drive axle → reduces traction
+            chassis::DriveTypes::RWD => -1.0, // weight shifts toward rear drive axle → increases traction
+            chassis::DriveTypes::AWD | chassis::DriveTypes::FourWD => 0.0, // net zero effect on total drive traction
         };
-        let max_trac_accel = self.chassis.wheel_fric_coef
-            * self.chassis.drive_axle_weight_frac
-            * uc::ACC_GRAV
-            / (1.0 * uc::R
-                + weight_transfer_sign * cg_height_abs * self.chassis.wheel_fric_coef
-                    / self.chassis.wheel_base);
+        let max_trac_accel =
+            self.chassis.wheel_fric_coef * self.chassis.drive_axle_weight_frac * uc::ACC_GRAV
+                / (1.0 * uc::R
+                    + weight_transfer_sign * cg_height_abs * self.chassis.wheel_fric_coef
+                        / self.chassis.wheel_base);
         let prev_speed = *self.state.speed_ach.get_stale(|| format_dbg!())?;
         let max_trac_speed = prev_speed + (max_trac_accel * dt);
         self.state

--- a/fastsim-py/src/lib.rs
+++ b/fastsim-py/src/lib.rs
@@ -47,7 +47,10 @@ fn fastsim(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     // List enabled features
     m.add_function(wrap_pyfunction!(fastsim_core::enabled_features, m)?)?;
 
-    m.add_function(wrap_pyfunction!(fastsim_core::simdrivelabel::get_label_fe_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        fastsim_core::simdrivelabel::get_label_fe_py,
+        m
+    )?)?;
 
     Ok(())
 }


### PR DESCRIPTION
Also applies cargo fmt and regenerates cal_and_val vehicles

Resolves #274